### PR TITLE
fixes to json serialization needed for datetime annotation procedure

### DIFF
--- a/annotator/annotator.py
+++ b/annotator/annotator.py
@@ -46,7 +46,7 @@ class AnnoDoc:
 
         json_obj['tiers'] = {}
         for name, tier in self.tiers.iteritems():
-            json_obj.tiers[name] = tier.to_json
+            json_obj['tiers'][name] = tier.to_json()
 
         return json.dumps(json_obj)
 
@@ -65,7 +65,14 @@ class AnnoTier:
         return len(self.spans)
 
     def to_json(self):
-        json.dumps([json.dumps(span.__dict__) for span in self.spans])
+
+        docless_spans = []
+        for span in self.spans:
+            span_dict = span.__dict__.copy()
+            del span_dict['doc']
+            docless_spans.append(span_dict)
+
+        return json.dumps(docless_spans)
 
     def next_span(self, span):
         """Get the next span after this one"""

--- a/annotator/geoname_annotator.py
+++ b/annotator/geoname_annotator.py
@@ -126,6 +126,10 @@ class GeonameAnnotator(Annotator):
         })
         geoname_results = list(geoname_cursor)
 
+        # ObjectId() cannot be JSON serialized and we have no use for them
+        for geoname_result in geoname_results:
+            del geoname_result['_id']
+
         # Associate spans with the geonames.
         # This is done up front so span information can be used in the scoring
         # function


### PR DESCRIPTION
fix json serialization by removing geonames _id, removing AnnoDoc objects from spans, and using correct syntax for tiers

The need for these fixes were discovered when attempting to use the jvm-nlp annotator for datetimes, because fuller AnnoDocs with other tiers are now being sent over the wire. 
