### PR TITLE
Applying hyphen replacement to AnnoDoc.text

### DIFF
--- a/annotator/annotator.py
+++ b/annotator/annotator.py
@@ -28,12 +28,15 @@ class AnnoDoc(object):
     # stripped of tags? This will ruin offsets.
 
     def __init__(self, text=None, date=None):
-        if type(text) is unicode or text:
+        if type(text) is unicode:
             self.text = text
         elif type(text) is str:
             self.text = unicode(text, 'utf8')
         else:
             raise TypeError("text must be string or unicode")
+        # Replacing the unicode dashes is done to avoid this pattern bug:
+        # https://github.com/clips/pattern/issues/104
+        self.text = self.text.replace(u"—", "-")
         self.tiers = {}
         self.properties = {}
         self.pattern_tree = None
@@ -76,9 +79,7 @@ class AnnoDoc(object):
         self.taxonomy = pattern.search.Taxonomy()
         self.taxonomy.append(pattern.search.WordNetClassifier())
         self.pattern_tree = pattern.en.parsetree(
-            # Replacing the unicode dashes is done to avoid this pattern bug:
-            # https://github.com/clips/pattern/issues/104
-            utils.dehyphenate_numbers_and_ages(self.text).replace(u"—", "-"),
+            utils.dehyphenate_numbers_and_ages(self.text),
             lemmata=True,
             relations=True
         )

--- a/annotator/ngram_annotator.py
+++ b/annotator/ngram_annotator.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 """Ngram Annotator"""
 
-import nltk
-
 from annotator import *
 from token_annotator import TokenAnnotator
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,12 @@
 --index-url https://pypi.python.org/simple/
-nltk>=3.0
+nltk==3.0.5
 requests
 pattern
-pymongo
+pymongo==2.7.2
 pyyaml
 unicodecsv
 lazy
-numpy
+numpy==1.10.0.post2
 geopy
 python-dateutil
 beautifulsoup

--- a/tests/annotator/test_old_case_count_annotator.py
+++ b/tests/annotator/test_old_case_count_annotator.py
@@ -14,6 +14,19 @@ class OldCaseCountAnnotatorTest(unittest.TestCase):
     def setUp(self):
         self.annotator = CaseCountAnnotator()
 
-    def test_article(self):
+    def test_slow_article(self):
+        """
+        This document is a test case because of a pattern bug that causes it
+        to take an extremely long time to parse as is.
+        https://github.com/clips/pattern/issues/104
+        """
         doc = AnnoDoc(u"2012 — — — — — — — — — — — — — — — — — — — — — — — — — — — — — — — — — — — — — — — — — — — — — — — — — — — — — — — — — — — — — — — — — the coordination of Epidemiological surveillance,")
+        doc.add_tier(self.annotator)
+    
+    def test_buggy_article(self):
+        """
+        The hypen was triggering an exception:
+        https://github.com/ecohealthalliance/annie/issues/31
+        """
+        doc = AnnoDoc("The authors say that a complex combination of factors—such as virus mutation")
         doc.add_tier(self.annotator)


### PR DESCRIPTION
Resolves #31 

Hyphen replacement is needed to avoid a Pattern bug, but it was triggering an error when computing byte offsets for the Pattern parse tree because it was only applied to the text processed by pattern so comparisons with the original text were failing. Now hyphen replacement is applied to the AnnoDoc text on initialization.

I also pinned some library versions in the requirements file because recent changes were causing some tests to fail.
