### PR TITLE
Add count annotator

### DIFF
--- a/annotator/count_annotator.py
+++ b/annotator/count_annotator.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python
+"""
+Annotates counts with the following attributes:
+cumulative, case, death, age, hospitalization, approximate, min, max
+"""
+import re
+from collections import defaultdict
+
+from annotator import Annotator, AnnoTier, AnnoSpan
+from jvm_nlp_annotator import JVMNLPAnnotator
+import result_aggregators as ra
+import utils
+
+class MatchSpan(AnnoSpan):
+    """
+    Class is used internally for creating temporary annotiers from match objects.
+    """
+    def __init__(self, match, doc):
+        self.start, self.end = doc.find_match_offsets(match)
+        self.doc = doc
+        self.label = match.string
+        self.match = match
+
+class CountSpan(AnnoSpan):
+    attributes = [
+        "annual",
+        "approximate",
+        "average",
+        "case",
+        "confirmed",
+        "cumulative",
+        "death",
+        "hospitalization",
+        "incremental",
+        "max",
+        "min",
+        "monthly",
+        "suspected",
+        "weekly",
+    ]
+    def __init__(self, count_match, doc):
+        offsets_tuple = doc.find_match_offsets(count_match)
+        self.start = offsets_tuple[0]
+        self.end = offsets_tuple[1]
+        self.doc = doc
+        self.label = count_match.string
+        match_dict = count_match.groupdict()
+        attributes = set([
+            attr for attr in self.attributes
+            if attr in match_dict
+        ])
+        if 'death' in attributes:
+            attributes.add('case')
+        self.metadata = {
+            'text': count_match.string,
+            'count': utils.parse_spelled_number(match_dict['count'].string),
+            'attributes': sorted(list(attributes))
+        }
+    def to_dict(self):
+        result = super(KeypointSpan, self).to_dict()
+        result.update(self.metadata)
+        return result
+
+class CountAnnotator(Annotator):
+    def annotate(self, doc):
+        if 'times' not in doc.tiers:
+            jvm_nlp_annotator = JVMNLPAnnotator(['times'])
+            doc.add_tier(jvm_nlp_annotator)
+        doc.setup_pattern()
+        my_search = doc.p_search
+        counts = ra.label('count', my_search('{CD+ and? CD? CD?}'))
+        # Next cull the false-positive counts from ages and dates.
+        match_tier = AnnoTier([
+            MatchSpan(count, doc)
+            for count in counts
+        ])
+        # Remove counts that overlap a time span.
+        doc.filter_overlapping_spans(
+            ['times', match_tier],
+            score_func=lambda x: 0 if isinstance(x, MatchSpan) else 1)
+        counts = [span.match for span in match_tier.spans]
+        counts = ra.combine([
+            counts,
+            ra.follows([my_search('AGE OF'), counts])
+        ], remove_conflicts=True)
+        count_modifiers = ra.combine([
+            ra.label('average', my_search('AVERAGE|MEAN')) +
+            ra.label('annual', my_search('ANNUAL|ANNUALLY')) +
+            ra.label('monthly', my_search('MONTHLY')) +
+            ra.label('weekly', my_search('WEEKLY')) +
+            ra.label('cumulative', my_search('TOTAL|CUMULATIVE|ALREADY')) +
+            ra.label('incremental', my_search('NEW|ADDITIONAL|RECENT')) +
+            ra.label('max', my_search('LESS|BELOW|UNDER|MOST|MAXIMUM|UP')) +
+            ra.label('min', my_search('GREATER|ABOVE|OVER|LEAST|MINIMUM|DOWN|EXCEED')) +
+            ra.label('approximate', my_search('APPROXIMATELY|ABOUT|NEAR|AROUND')),
+        ])
+        count_descriptions = ra.near([count_modifiers, counts]) + counts
+        case_descriptions = map(utils.restrict_match, (
+            ra.label('death',
+                my_search('DIED|DEATH|FATALITIES|KILLED|CLAIMED')
+            ) +
+            ra.label('hospitalization',
+                my_search('HOSPITAL|HOSPITALIZED')
+            ) +
+            ra.label('case',
+                my_search(
+                    'CASE|INFECTION|INFECT|STRICKEN'
+                )
+            )
+        ))
+        case_statuses = map(utils.restrict_match, (
+            ra.label('suspected',
+                my_search('SUSPECTED')
+            ) +
+            ra.label('confirmed',
+                my_search('CONFIRMED')
+            )
+        ))
+        case_descriptions = ra.combine([
+            ra.follows([case_statuses, case_descriptions]),
+            case_descriptions
+        ])
+        person_descriptions = map(utils.restrict_match, my_search('PERSON|CHILD|ADULT|ELDER|PATIENT|LIFE'))
+        person_counts = ra.follows([
+            count_descriptions,
+            ra.label('case', person_descriptions)
+        ], 2)
+        case_descriptions_with_counts = ra.near([
+            case_descriptions,
+            ra.combine([
+                ra.near([counts, count_modifiers]) +
+                ra.near([counts, count_modifiers, count_modifiers], outer=False),
+                count_descriptions
+            ], prefer='match_length')
+        ], 3)
+        annotated_counts = ra.combine([
+            case_descriptions_with_counts,
+            #Ex: Deaths: 13
+            ra.follows([
+                ra.label('death', my_search('DEATHS :?')),
+                counts
+            ]),
+            person_counts,
+            count_descriptions
+        ], prefer='match_length')
+        doc.tiers['counts'] = AnnoTier([
+            CountSpan(count, doc)
+            for count in annotated_counts
+        ])
+        doc.tiers['counts'].sort_spans()
+        return doc

--- a/annotator/result_aggregators.py
+++ b/annotator/result_aggregators.py
@@ -16,6 +16,7 @@ class MetaMatch(pattern.search.Match):
         self.labels = labels
         min_idx = min([m.words[0].abs_index for m in matches])
         max_idx = max([m.words[-1].abs_index for m in matches])
+        assert min_idx <= max_idx
         self.words = matches[0].words[0].doc_word_array[min_idx:max_idx + 1]
     def __repr__(self):
         return "MetaMatch(" + ", ".join(map(str, self.matches)) + ")"
@@ -46,9 +47,7 @@ class MetaMatch(pattern.search.Match):
                 yield match
     def match_length(self, include_overlap=False):
         """
-        Return the cumulative length of all the submatches rather than the
-        length of the meta match's span including space between submatches
-        (which len() would return).
+        Return the number of tokens in the match.
         """
         word_indices = {}
         for match in self.iterate_matches():
@@ -61,7 +60,7 @@ class MetaMatch(pattern.search.Match):
     def constituents(self):
         return self.words
 
-def near(results_lists, max_words_between=30):
+def near(results_lists, max_words_between=30, outer=True):
     """
     Returns matches from mulitple results lists that appear in the same sentence
     within the given proximity.
@@ -75,7 +74,7 @@ def near(results_lists, max_words_between=30):
         if (isinstance(rl, list) and len(rl) > 0) or
            (isinstance(rl, tuple) and len(rl[1]) > 0)
     ]
-    for i in range(2, len(non_empty_lists) + 1):
+    for i in range(2 if outer else len(non_empty_lists), len(non_empty_lists) + 1):
         for permutation in itertools.permutations(non_empty_lists, i):
             result += follows(permutation, max_words_between, max_overlap=10)
     return result

--- a/tests/annotator/test_case_count_annotator.py
+++ b/tests/annotator/test_case_count_annotator.py
@@ -145,21 +145,6 @@ class CaseCountAnnotatorTest(unittest.TestCase):
             }
         )
 
-    # With the combined patient description / caseCount annotator the span of
-    # text no longer corresponds to the count.
-    # def test_numbers_last_pattern(self):
-    #     """Make sure we can get the proper offsets if we have a numeric portion
-    #       that comes at the end of the pattern."""
-
-    #     doc = AnnoDoc("The number of cases exceeds 30")
-    #     doc.add_tier(self.annotator)
-
-    #     self.assertEqual(len(doc.tiers['patientInfo']), 1)
-    #     self.assertEqual(doc.tiers['patientInfo'].spans[0].start, 28)
-    #     self.assertEqual(doc.tiers['patientInfo'].spans[0].end, 30)
-    #     self.assertEqual(doc.tiers['patientInfo'].spans[0].label, 30)
-    #     self.assertEqual(doc.tiers['patientInfo'].spans[0].type, 'caseCount')
-
     def test_misc(self):
         doc = AnnoDoc("1200 children between the ages of 2 and 5 are afflicted with a mystery illness")
         doc.add_tier(self.annotator)
@@ -177,7 +162,7 @@ class CaseCountAnnotatorTest(unittest.TestCase):
         )
 
     def test_misc2(self):
-        doc = AnnoDoc("These 2 new cases bring to 4 the number stricken in California this year [2012].")
+        doc = AnnoDoc("These 2 new cases bring to 4 the number stricken in California.")
         doc.add_tier(self.annotator)
         test_utils.assertHasProps(
             doc.tiers['patientInfo'].spans[0].metadata, {
@@ -324,7 +309,6 @@ class CaseCountAnnotatorTest(unittest.TestCase):
             }
         )
     def test_hyphenated_numbers(self):
-
         doc = AnnoDoc("There have been nine hundred ninety-nine reported cases.")
         doc.add_tier(self.annotator)
         test_utils.assertHasProps(
@@ -335,38 +319,5 @@ class CaseCountAnnotatorTest(unittest.TestCase):
             }
         )
 
-
 if __name__ == '__main__':
     unittest.main()
-
-# TODO -- enable these once our aspirations have been achieved.
-
-"""
-
-    import os, sys; sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
-import unittest
-from diagnosis.feature_extractors import extract_counts
-
-class TestCountExtractorAspirations(unittest.TestCase):
-    def test_vague(self):
-        example = "Hundreds of people have possibly contracted the disease cholera over the past few days"
-        actual_count = 200
-        count_obj = next(extract_counts(example), {})
-        self.assertEqual(count_obj.get('type'), "caseCount")
-        self.assertEqual(count_obj.get('aproximate'), True)
-        self.assertEqual(count_obj.get('value'), actual_count)
-    def test_location_association(self):
-        example = "500 new MERS cases that Saudi Arabia has reported in the past 3 months appear to have occurred in hospitals"
-        actual_count = 500
-        count_obj = next(extract_counts(example), {})
-        self.assertEqual(count_obj.get('location'), "Saudi Arabia")
-        self.assertEqual(count_obj.get('value'), actual_count)
-    def test_time_association(self):
-        example = "Since 2001, the median annual number of cases in the U.S. was 60"
-        actual_count = 60
-        count_obj = next(extract_counts(example), {})
-        self.assertEqual(count_obj.get('time'), "2001")
-        self.assertEqual(count_obj.get('valueModifier'), "median")
-        self.assertEqual(count_obj.get('value'), actual_count)
-
-"""

--- a/tests/annotator/test_count_annotator.py
+++ b/tests/annotator/test_count_annotator.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python
+"""
+Tests our ability to annotate sentences with numerical
+instances of infections, hospitalizations and deaths.
+"""
+
+import sys
+import unittest
+import test_utils
+
+sys.path = ['./'] + sys.path
+
+from annotator.annotator import AnnoDoc
+from annotator.count_annotator import CountAnnotator
+
+class TestCountAnnotator(unittest.TestCase):
+
+    def setUp(self):
+        self.annotator = CountAnnotator()
+
+    def test_verb_counts(self):
+        examples = [
+            ("it brings the number of cases reported to 28 in Jeddah since 27 Mar 2014", 28),
+            ("There have been nine hundred ninety-nine reported cases.", 999)
+        ]
+        for example, actual_count in examples:
+            doc = AnnoDoc(example)
+            doc.add_tier(self.annotator)
+            self.assertEqual(len(doc.tiers['counts']), 1)
+            test_utils.assertHasProps(
+                doc.tiers['counts'].spans[0].metadata, {
+                    'count': actual_count,
+                    'attributes': ['case']
+                })
+
+    def test_death_counts(self):
+        examples = [("The number of deaths is 30", 30),
+                    # Also test unicode
+                    (u"The number of deaths is 30", 30),
+                    ("Nine patients died last week", 9)]
+        for example, actual_count in examples:
+            doc = AnnoDoc(example)
+            doc.add_tier(self.annotator)
+            self.assertEqual(len(doc.tiers['counts']), 1)
+            test_utils.assertHasProps(
+                doc.tiers['counts'].spans[0].metadata, {
+                    'count': actual_count,
+                    'attributes': ['case', 'death']
+                })
+
+    def test_offsets(self):
+        doc = AnnoDoc("The ministry of health reports seventy five new patients were admitted")
+        doc.add_tier(self.annotator)
+        self.assertEqual(len(doc.tiers['counts']), 1)
+        self.assertEqual(doc.tiers['counts'].spans[0].start, 31)
+        self.assertEqual(doc.tiers['counts'].spans[0].end, 56)
+        test_utils.assertHasProps(
+            doc.tiers['counts'].spans[0].metadata, {
+                'count' : 75
+            }
+        )
+
+    def test_written_numbers(self):
+        doc = AnnoDoc("two hundred and twenty two patients were admitted to hospitals")
+        doc.add_tier(self.annotator)
+        self.assertEqual(len(doc.tiers['counts']), 1)
+        test_utils.assertHasProps(
+            doc.tiers['counts'].spans[0].metadata, {
+                'count': 222
+            }
+        )
+
+    def test_hospitalization_counts1(self):
+        examples = [("33 were hospitalized", 33),
+                    ("222 were admitted to hospitals with symptoms of diarrhea", 222)]
+        for example, actual_count in examples:
+            doc = AnnoDoc(example)
+            doc.add_tier(self.annotator)
+            self.assertEqual(len(doc.tiers['counts']), 1)
+            test_utils.assertHasProps(
+                doc.tiers['counts'].spans[0].metadata, {
+                    'count': actual_count,
+                    'attributes': ['hospitalization']
+                })
+
+    def test_death_counts_pattern_problem(self):
+        """The issue here is that CLIPS pattern library will tokenize colons
+           separately from the preceding word."""
+
+        doc = AnnoDoc("Deaths: 2")
+        doc.add_tier(self.annotator)
+
+        self.assertEqual(len(doc.tiers['counts']), 1)
+        self.assertEqual(doc.tiers['counts'].spans[0].start, 0)
+        self.assertEqual(doc.tiers['counts'].spans[0].end, 9)
+        test_utils.assertHasProps(
+            doc.tiers['counts'].spans[0].metadata, {
+                'count': 2
+            })
+
+    def test_age_elimination(self):
+        doc = AnnoDoc("1200 children under the age of 5 are afflicted with a mystery illness")
+        doc.add_tier(self.annotator)
+        test_utils.assertHasProps(
+            doc.tiers['counts'].spans[0].metadata, {
+                'count' : 1200
+            }
+        )
+        self.assertEqual(len(doc.tiers['counts'].spans), 1)
+
+    def test_raw_counts(self):
+        doc = AnnoDoc("There are 5 new ones.")
+        doc.add_tier(self.annotator)
+        test_utils.assertHasProps(
+            doc.tiers['counts'].spans[0].metadata, {
+                'count' : 5,
+                'attributes': ['incremental']
+            }
+        )
+        self.assertEqual(len(doc.tiers['counts'].spans), 1)
+
+    def test_complex(self):
+        examples = [
+            ("These 2 new cases bring to 4 the number stricken in California this year [2012].", [
+                {'count': 2, 'attributes': ['case', 'incremental']},
+                {'count': 4, 'attributes': ['case']},
+            ]),
+            ("Two patients died out of four patients.", [
+                {'count': 2, 'attributes': ['case', 'death']},
+                {'count': 4, 'attributes': ['case']},
+            ]),
+        ]
+        for example in examples:
+            sent, counts = example
+            doc = AnnoDoc(sent)
+            doc.add_tier(self.annotator)
+            self.assertEqual(len(doc.tiers['counts'].spans), len(counts))
+            for actual, expected in zip(doc.tiers['counts'].spans, counts):
+                test_utils.assertHasProps(actual.metadata, expected)
+
+    def test_cumulative(self):
+        examples = [
+            ("In total nationwide, 2613 cases of the disease have been reported as of 2 Jul 2014, with 63 deaths", [
+                {'count': 2613, 'attributes': ['case', 'cumulative']},
+                {'count': 63, 'attributes': ['case', 'death']}
+            ]), 
+            ("it has already claimed about 455 lives in Guinea", [
+                {'count': 455, 'attributes': ['approximate', 'case', 'cumulative', 'death']}
+            ])
+        ]
+        for example in examples:
+            sent, counts = example
+            doc = AnnoDoc(sent)
+            doc.add_tier(self.annotator)
+            self.assertEqual(len(doc.tiers['counts'].spans), len(counts))
+            for actual, expected in zip(doc.tiers['counts'].spans, counts):
+                test_utils.assertHasProps(actual.metadata, expected)
+
+    def test_attributes(self):
+        examples= [
+            ("There have been 12 reported cases in Colorado. " +
+            "There was one suspected case of bird flu in the country.", [
+                { 'count': 12, 'attributes': ['case'] },
+                { 'count': 1, 'attributes': ['case', 'suspected'] }
+            ]),
+            ("The average number of cases reported annually is 600", [
+                { 'count': 600, 'attributes': ['annual', 'average', 'case'] }
+            ])
+        ]
+        for example in examples:
+            sent, counts = example
+            doc = AnnoDoc(sent)
+            doc.add_tier(self.annotator)
+            self.assertEqual(len(doc.tiers['counts'].spans), len(counts))
+            for actual, expected in zip(doc.tiers['counts'].spans, counts):
+                test_utils.assertHasProps(actual.metadata, expected)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This adds a CountAnnotator class that will be used to replace the CaseCountAnnotator and PatientInfoAnnotator. CountAnnotator combines the simplicity of the CaseCountAnnotator with the result aggregator approach used for finding counts used in the PatientInfoAnnotator. It differs from both annotators in that all counts are annotated, even if they are not clearly case counts, so they can be highlighted in the EIDR-C incident suggestion modal. It is also better at separating dates from case counts.

This also updates the find_maximum_weight_interval_set algorithm so it is not dependent on limited precision floats for weights.