### PR TITLE
Fix too many variables bug on large articles

### DIFF
--- a/annotator/count_annotator.py
+++ b/annotator/count_annotator.py
@@ -9,6 +9,9 @@ from annotator import Annotator, AnnoTier, AnnoSpan
 from jvm_nlp_annotator import JVMNLPAnnotator
 import result_aggregators as ra
 import utils
+import logging
+logging.basicConfig(level=logging.ERROR, format='%(asctime)s %(message)s')
+logger = logging.getLogger(__name__)
 
 class CountSpan(AnnoSpan):
     attributes = [
@@ -94,7 +97,7 @@ def is_valid_count(count_string):
     try:
         if int(value) != value: return False
     except (TypeError, ValueError) as e:
-        print "Cannot parse count string: " + count_string
+        logger.info("Cannot parse count string: " + count_string)
         return False
     if value > 1000000000: return False
     return True
@@ -117,7 +120,7 @@ class CountAnnotator(Annotator):
                 count_matches.append(MatchSpan(ne_span, word_spans))
         counts = ra.label('count', count_matches)
         def search_regex(regex_term):
-            regex = re.compile(r"^"+regex_term+r"$", re.I)
+            regex = re.compile(r"^" + regex_term + r"$", re.I)
             match_spans = []
             for word_span in word_tier.spans:
                 if regex.match(word_span.text):

--- a/annotator/result_aggregators.py
+++ b/annotator/result_aggregators.py
@@ -37,11 +37,11 @@ class MetaMatch(pattern.search.Match):
         return out
     def iterate_matches(self):
         """
-        Iterate over all the plain match objects nested in MetaMatches
+        Iterate over all the matchs nested in MetaMatches
         """
         for match in self.matches:
             if isinstance(match, MetaMatch):
-                for match2 in match.matches:
+                for match2 in match.iterate_matches():
                     yield match2
             else:
                 yield match

--- a/annotator/token_annotator.py
+++ b/annotator/token_annotator.py
@@ -24,21 +24,18 @@ class TokenAnnotator(Annotator):
 
         spans = []
         index = 0
-        tail = doc.text
 
         for token in tokens:
 
-            while not tail.startswith(token):
+            while not doc.text[index:index+500].startswith(token):
                 # TODO make this safer. There are certain characters
                 # that we should be willing to consume, but not all. There should
                 # be an error raised if we find non-word-breaking characters
                 # where we expected the next token.
                 index += 1
-                tail = tail[1:]
 
             spans.append(AnnoSpan(index, index + len(token), doc, label=token))
             index += len(token)
-            tail = tail.replace(token, '', True)
 
         doc.tiers['tokens'] = AnnoTier(spans)
 

--- a/tests/annotator/resources/WhereToItaly.anc
+++ b/tests/annotator/resources/WhereToItaly.anc
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<cesHeader xmlns="http://www.xces.org/ns/GrAF/1.0/" creator="KBS" date.created="2005-08-29"
+           version="1.0.4">
+    <fileDesc>
+        <titleStmt>
+            <title>Italy</title>
+        </titleStmt>
+        <extent wordCount="41363"/>
+        <sourceDesc>
+            <title>Italy</title>
+            <publisher>Langenscheidt</publisher>
+            <pubPlace>USA</pubPlace>
+        </sourceDesc>
+    </fileDesc>
+    <profileDesc>
+        <textClass catRef="WR TG">
+            <domain>Leisure</domain>
+            <subdomain>Travel</subdomain>
+            <subject>Places to see</subject>
+            <audience>Adult</audience>
+            <medium>Book</medium>
+        </textClass>
+        <primaryData loc="WhereToItaly.txt" medium="text"/>
+        <annotations>
+            <annotation ann.loc="WhereToItaly.txt" type="content">Text content</annotation>
+            <annotation ann.loc="WhereToItaly-logical.xml" type="logical">Logical structure</annotation>
+            <annotation ann.loc="WhereToItaly-s.xml" type="s">Sentence boundaries</annotation>
+            <annotation ann.loc="WhereToItaly-hepple.xml" type="hepple">Hepple part of speech tags</annotation>
+            <annotation ann.loc="WhereToItaly-vp.xml" type="vp">Verb chunks</annotation>
+            <annotation ann.loc="WhereToItaly-np.xml" type="np">Noun chunks</annotation>
+        </annotations>
+    </profileDesc>
+    <revisionDesc>
+        <change>
+            <changeDate>2005-08-29</changeDate>
+            <respName>Keith Suderman</respName>
+            <item>Updated to v1.0.4 with complete standoff markup</item>
+            <item>Added Brill part of speech tags</item>
+            <item>Fixed sentence boundaries</item>
+        </change>
+    </revisionDesc>
+</cesHeader>

--- a/tests/annotator/resources/WhereToItaly.txt
+++ b/tests/annotator/resources/WhereToItaly.txt
@@ -1,0 +1,4166 @@
+
+  
+  
+    
+      
+        WHERE TO GO
+        Planning an Italian vacation entails a series of difficult
+        decisions. “ Doing” Italy is a lifetime job, and many devotees are so
+        in love with the place that they won’t even think of an alternative
+        destination. After a predictable first romance with Rome, Venice, or
+        Florence, they spend the rest of their lives systematically working
+        their way through the small but wildly varied country, region by
+        region, visit after visit. If this is your first trip, you’ll do well
+        to establish an overall impression. If the seduction works, and it
+        usually does, you’ll want to come back time and again.
+        This section includes all the most important towns and
+        regions to help you make your choice. Each of the five areas has a
+        principal city as a focus or starting point: Rome for central Italy,
+        plus Sardinia; Florence for Tuscany, with Umbria, and the Adriatic
+        seaside resorts to the east; Venice for Veneto, the Dolomites, and
+        Emilia’s historic towns from Parma to Ravenna; Milan for Lombardy,
+        Piedmont, and the Italian Riviera to the west; and Naples for the south
+        and Sicily.
+        Given the sheer and unrivaled richness of Italy, the
+        selection of places within those five areas is not in any way
+        exhaustive (nor, by the same token, exhausting). Those who already know
+        Italy well will inevitably feel that a few of their favorite spots have
+        been neglected (though they may also be grateful to not have their
+        secret exposed), while they’ll find others they never heard of.
+        Newcomers will have an embarrassment of destinations to choose
+        from.
+        Depending on how much time you have for that all-important
+        first taste, we suggest you try to visit at least two, even three of
+        the regions. Those with a passion for the big city can combine Rome
+        with the artistic delights of Florence and Tuscany, or Milan with the
+        magical romance of Venice. For many, the key to Italy’s Mediterranean
+        soul is to be found in Naples and the south. After the intense emotion
+        and summertime heat spells (air conditioning is not always available),
+        cool off at the seaside resorts of the Riviera or any of the gem-like
+        islands.
+        The trick is in the mix. Not just geographically, in
+        exploring the variety and contrasts of north and south, but in
+        combining the attractions of town and countryside and the resultingly
+        different facets of Italy’s daily life. Nowhere is it easier or more
+        delightful to overdose on museums and monuments than in Italy. A dear
+        old lady returned from her first visit with the observation: “Italy’s
+        very nice, very nice indeed, but for my taste, much too much history. ”
+        While it would be a crime to ignore the churches, palazzos, and museums
+        chronicling the unparalleled glories of Italy’s history, the best way
+        to enjoy them is also to spend plenty of time soaking it in from a
+        front-row seat in a café, or from under a canvas beach umbrella
+        watching seaside life unfold. The siesta is one of the greatest of all
+        Latin institutions, and the most important Italian expression you may
+        ever learn is dolce far niente (the sweetness of doing nothing).
+        Many people cannot manage to go to Italy outside the major
+        holiday periods — Easter, July, and August. But if your options are
+        more flexible, the most enjoyable (though equally crowded) months are
+        May, June, September, and October — especially for Rome, Venice, and
+        Tuscany. Certainly, July and August can be almost unbearably hot and
+        humid in most big cities, but some find an odd, ghostly pleasure in
+        being in Rome on Ferragosto (on and around 15 August) when the city is
+        abandoned “to the cats and the crazy. ” And remember, Italians make no
+        bones about public holidays (see page 233); they just close the whole
+        country down.
+        Getting Around
+        Even the most free-spirited traveler can use a little help
+        occasionally. With the tourist industry such a vital factor in the
+        economy, Italy has an elaborate network of information offices.
+        Bureaucrats being bureaucrats, efficiency and amiability vary from
+        place to place, but the tourist information offices all provide useful
+        maps and brochures.
+        For general information, the state tourist office ENIT
+        (Ente Nazionale Italiano per il Turismo) has offices in major foreign
+        cities as well as regional capitals. When in Italy, look instead for
+        the APT (Azienda di Promozione Turistica) for more detailed regional
+        sightseeing information; they occasionally help as well with hotel and
+        camping accommodation. CIT (Compagnia Italiana di Turismo) is a
+        national travel agency for transportation, excursions, and hotel
+        bookings.
+        The Travel Tips section at the back of the book (see page
+        217) gives detailed practical guidance on the technicalities of travel
+        through Italy, but here are some general thoughts to help you plan your
+        trip.
+        Major journeys from one part of the country to another,
+        say, from Milan to Rome or down to Naples, is most enjoyed by train
+        buffs and travelers with plenty of time, patience, and curiosity. The
+        uncertainties of schedules and frequency of strike action gradually
+        disappeared in the 1990s, but the occasional wrinkle still needs to be
+        ironed out. If you are making a long rail journey, don’t rely on the
+        generally dreary dining-car service. Make up your own picnic hamper of
+        cold meats, bread, cheese, fruit, and water or wine from the local
+        market before you get aboard. Very often, you end up sharing it with
+        Italian passengers who offer in exchange their own homemade
+        goodies.
+        The great breathtaking Italian adventure remains the road.
+        The autostrada (toll motorway or expressway) runs the length and
+        breadth of the peninsula, a challenge to the imagination and survival
+        instincts of Western civilization. Only to the uninitiated do Italian
+        drivers seem dangerous. Most of them are highly skillful — they have to
+        be — and proud of their reflexes. Two attitudes to avoid: recklessness
+        and excessive caution. Don’t try to match their improvisations, you
+        will only raise their competitive spirit into the realm of high risk.
+        They may be similarly provoked by indecisive and slow drivers.
+        Keep your car for use on the open road. In the overcrowded
+        cities, just drop your bags off at the hotel, and then park your car.
+        To see the city, you should walk, take a bus, subway or taxi, or rent a
+        bike. Most towns have solved the problem for you by closing off their
+        historical centers (centro storico) to traffic: Consider that your
+        rental cars will cost you money while remaining unused albeit safely
+        parked.
+        Try to vary the kind of places that you stay in. Italy has
+        all types of accommodations available, so you’ll have quite a few
+        choices. Small family-run hostelries and country inns are charming,
+        but, depending of course on your budget and personal preferences,
+        consider indulging for at least one night on the special comforts and
+        pampering of the great hotels. Look for converted monasteries and
+        countryside farmhouses. In most cases the frugality has long gone, the
+        heating is modern, and the medieval well has been replaced by a
+        swimming pool, but the setting is still memorable.
+        Even if you’re a linguistic dud, try to learn a handful of
+        Italian words or expressions. The pronunciation is remarkably easy and
+        the Italians are usually delighted by anyone making the effort. A
+        cheerful buon giorno (good day) or buona sera (good evening) can work
+        wonders when entering or leaving a shop or restaurant. In a land where
+        politeness is important, per favore (please), grazie (thank you), prego
+        (don’t mention it), and, when pushing through a bus or market, permesso
+        (excuse me) will be greatly appreciated. You’ll find some additional
+        phrases beginning on page 218. Now enjoy it, buon viaggio!
+        CENTRAL ITALY
+        The center of Italy is the cradle of Latin civilization,
+        one-time administrative headquarters of that ancient conglomerate known
+        as the Roman Empire. Immediately surrounding Rome, today’s Lazio is the
+        ancient province of Latium. On the eastern flank of the Apennines, the
+        Abruzzi region, of which the province of Molise is a recently created
+        offshoot, came under Roman domination in the third century b.c.
+        First-time visitors will understandably want to spend most or all of
+        their time in Rome, but the area surrounding the capital makes a
+        pleasant excursion within fairly easy reach of Rome for those
+        adventurers with wheels and extra time.
+        The rugged island of Sardinia deserves at least a week to
+        do it justice, but you may want to spend a long weekend at one of its
+        attractive little seaside resorts.
+        Rome
+        Crowning seven hills along the winding banks of the River
+        Tiber, Rome has numerous different personalities: ancient Rome of
+        imperial ruins; Catholic Rome of Vatican City and countless churches;
+        the Renaissance city of Michelangelo and Raphael or the Baroque of
+        Bernini and Borromini; and a modern metropolis of interminable traffic
+        jams, fashionable boutiques and cafés, as well as factories and
+        characterless apartment buildings that make up the post-war eye-sore
+        suburbs.
+        None is easily separable from the others. The secret of the
+        Eternal City’s magic is that it lives and relishes all its ages
+        simultaneously. Churches are commonly built on the ruins of Roman baths
+        or pagan temples. The trendy café crowd on Piazza Navona draw natural
+        inspiration from Bernini’s grandiose 17th-century fountain.
+        Ease yourself into this magnificent city that has hosted
+        visitors for millenia. To know its every crook and cranny is a daunting
+        challenge, but concentrate on the ancient city around the Colosseum or
+        the Vatican’s formidable complex, and come to know one age at a
+        time.
+        The Center
+        Make an early start with breakfast (or come back for a late
+        afternoon apéritif) on Piazza del Popolo at Caffè Rosati, a veritable
+        Roman institution and historical meeting-place of the city’s literary
+        personalities. Its outdoor tables are a perfect vantage point for
+        admiring the gracefully curving piazza, an exemplary piece of open-air
+        urban theater designed in 1816 by Giuseppe Valadier, architect to
+        Napoleon.
+        On the north side, the church of Santa Maria del Popolo is
+        important for Raphael’s Chigi Chapel, exquisite frescoes by
+        Pincuricchio, and, above all, two profoundly disturbing early
+        17th-century paintings by Caravaggio, the Conversion of St. Paul and
+        Crucifixion of St. Peter, in the Cerasi Chapel left of the choir.
+        Next to the church, an arched 16th-century gateway marks
+        what was the entrance to ancient and medieval Rome along the Via
+        Flaminia, leading from Rimini on the Adriatic coast. The obelisk in the
+        piazza’s center, dating from the Egypt of Rameses II (13th century b.c.
+        ), was brought here from the Circus Maximus and re-erected by Pope
+        Sixtus V in 1589. Rounding off the south side are the twin Baroque
+        churches, Santa Maria dei Miracoli and Santa Maria in Montesanto,
+        completed by the 17th-century masters Gianlorenzo Bernini and Carlo
+        Fontana.
+        Above the piazza to the east, the Pincio gardens offer a
+        magical view of the city, especially at sunset. (For the great art
+        museum in the Villa Borghese park behind the Pincio, see page 66. ) The
+        ascending Pincio promenade lined with umbrella pine trees takes you
+        past the Villa Medici, home of many French artists visiting on national
+        scholarships, to the 16th-century French church, Trinità dei Monti.
+        Its twin belfries loom over the Spanish Steps (Scalinata
+        della Trinità dei Monti), eternal hang-out of Rome’s golden youths,
+        lovers, peddlers of trinkets and the occasional hustler. The pleasant
+        daze induced on the three-tiered travertine staircase, festooned in
+        spring with pink azaleas, was celebrated by John Keats as a “blissful
+        cloud of summer indolence” before he died here in 1821. His house at
+        the bottom of the steps has been preserved as a museum.
+        Named after a palace used as the Spanish Embassy, the
+        famous steps and the Piazza di Spagna are the heart of the city’s most
+        fashionable and exclusive shopping enclave, leading to the Via del
+        Corso. The piazza’s 17th-century sunken-boat-shaped marble fountain,
+        Fontana della Barcaccia, is by the great Bernini’s father. The nearby
+        venerable Babington’s Tea Rooms are a relic of the days when Romans
+        called the piazza the “English ghetto. ” More quintessentially Roman,
+        on nearby Via Condotti, is the city’s oldest coffee house, the
+        18th-century Caffè Greco — popular, as you’ll see from pictures, busts,
+        and autographs, with Goethe, Byron, Baudelaire, Liszt, Casanova, and
+        Fellini.
+        This is the general area of the Trevi Fountain (Fontana di
+        Trevi) which benefited from Fellini’s keen sense of Baroque aesthetics
+        when he dipped the dazzling Anita Ekberg in its legendarily purifying
+        waters for his film La Dolce Vita. It’s been quite some time since
+        anyone was caught romping in these waters reflecting Nicola Salvi’s
+        astounding 18th-century fountain. It is in fact a triumphal arch and
+        palace façade (to the old Palazzo Poli) framing mythic creatures in a
+        riot of rocks and pools, with a rearing horse symbolizing the ocean’s
+        turmoil and a calmer steed its tranquility. Tucked away behind narrow
+        alleys, this recently restored extravaganza is out of all proportion to
+        its tiny piazza and no amount of signposts leading to it can prepare
+        you for the marvellous shock of discovery. Romantics go at the dead of
+        night, to be alone with its illumination. It’s a favorite haunt for
+        local fellows looking for foreign innocents abroad. Tradition dictates
+        a toss of a coin over your shoulder to ensure a return trip.
+        That other symbol of la dolce vita, the Via Veneto, has
+        been deserted by its starlets and paparazzi and only the expensive
+        cafés, once stylish shops, and five-star hotels remain. Slowly, it is
+        making something of a comeback in popularity.
+        On one of the seven hills of ancient Rome, the
+        fortress-like Palazzo del Quirinale, once summer residence to popes
+        fleeing the malarial swamps of the Vatican down by the Tiber, housed
+        the new king of Italy after 1870, and since 1947 is the presidential
+        palace. The only embellishment on its formidable façade is Bernini’s
+        graceful porch, but its piazza is worth the climb for the view over the
+        city and the Vatican.
+        You couldn’t miss Piazza Venezia if you tried — and many do
+        try, because of its endless traffic jams and the arguably ungainly
+        white marble Vittorio Emanuele Monument. The monument celebrates the
+        first king of unified Italy as well as the Tomb of the Unknown Soldier
+        with inimitable 19th-century pomposity. Northwest of the monument, the
+        15th-century Palazzo Venezia is a fine example of severe but elegant
+        early Renaissance architecture, now containing a museum of medieval and
+        Renaissance arms, furniture, and sculpture. Mussolini had his office
+        there and harangued his followers from the balcony.
+        Beside the Piazza Venezia, a steep staircase leads up to
+        the austere 13th-century Santa Maria in Aracoeli, while another, more
+        graceful and gradual, takes you up between the statues of Castor and
+        Pollux to Michelangelo’s beautifully proportioned square of the
+        Campidoglio (Capitoline Hill). This quiet traffic-free haven forges a
+        superb link between the Renaissance and ancient Rome’s most sacred
+        site, where sacrifices were made to Jupiter and Juno. The grand bronze
+        equestrian statue of Marcus Aurelius that anchors the piazza’s center
+        is a copy; the restored original from the second century a.d. is
+        sheltered within the Palazzo Nuovo museum to its left. Opposite stands
+        the Palazzo dei Conservatori, and at the rear of the square is the
+        handsome 16th-century façade of the Palazzo Senatorio (now the City
+        Hall). These two palazzos house the Capitoline Museums (see page 66),
+        whose Greek and Roman collections provide an excellent introduction to
+        the ancient Roman Forum that spreads below it.
+        The church of the Gesù, severe and relatively discreet on
+        its own square west of the Piazza Venezia, was a major element in the
+        Jesuits’ Counter-Reformation campaign. Begun as their Roman
+        “headquarters” in 1568, its open ground plan was the model for the
+        Congregational churches that were to regain popular support from the
+        Protestant faith. While its façade is more sober than the exultant
+        Baroque churches put up as the movement gained momentum, the interior
+        glorifies the new militancy in gleaming bronze, gold, marble, and
+        precious stones. Perhaps inevitably, the church’s most elaborate
+        ornament is the altar of St. Ignatius Loyola, covering the tomb of the
+        Jesuits’ Spanish founder in the left transept. Its profusion of lapis
+        lazuli is actually a thin shell fused to plaster stucco.
+        In gentler contrast, the nearby church of Sant’Ignazio
+        stands in an enchanting Rococo stage-set of 17th-century houses.
+        Inside, Andrea Pozzo (himself a Jesuit priest and designer of the
+        saint’s tomb at the Gesù) has painted a superb trompe l’oeil ceiling
+        fresco (1685) depicting St. Ignatius’ entry into paradise.
+        The circular Pantheon (Piazza della Rotonda) is the
+        best-preserved monument of ancient Rome and rivals the Colosseum in its
+        combination of quiet elegance and sheer massive power. Built by Emperor
+        Hadrian around a.d. 125 on an earlier site destroyed by fire, it
+        achieved a marvel of engineering with its magnificent coffered dome:
+        over 43 m (141 ft) in interior diameter (larger than St. Peter’s),
+        exactly equal to its height. Bronze that once embellished the entrance
+        was carted away and recycled as Bernini’s canopy for the high altar in
+        St. Peter’s. This “Temple of all the Gods” today contains the tombs of
+        Renaissance masters such as Raphael as well as the first king of Italy
+        Vittorio Emanuele II and his son Umberto I.
+        Caravaggio admirers will find some of his greatest
+        masterpieces right in the neighborhood: the St. Matthew trilogy in the
+        fine Baroque church of San Luigi dei Francesi, and the moving Madonna
+        of the Pilgrims in the Renaissance church of Sant’Agostino.
+        Pause now at a café in that most serene of city squares,
+        the Piazza Navona. Nowhere in Rome is the spectacle of Italian street
+        life more pleasantly indulged, thanks to an inspired collaboration of
+        Roman genius across the ages. The elongated oval piazza was laid out
+        around a.d. 79 by Emperor Domitian as an athletics stadium, Circus
+        Agonalis — a sporting tradition continued in the Middle Ages with
+        jousting tournaments and other events in the centuries that followed.
+        The 17th century contributed its sublime Baroque décor, and today it is
+        protected as Rome’s most beloved square. In the center, Bernini’s
+        Fountain of the Four Rivers (Fontana dei Fiumi) celebrates the great
+        rivers of the four continents: the Americas (Río de la Plata), Europe
+        (Danube), Asia (Ganges), and Africa (Nile). Romans who delight in
+        Bernini’s scorn for his rivals suggest that the Nile god covers his
+        head rather than look at Borromini’s church of Sant’Agnese in Agone,
+        and the river god of the Americas is poised to catch it in case it
+        collapses. In fact, the fountain was completed several years before
+        Borromini’s splendid — and structurally impeccable — façade and
+        dome.
+        A large and boisterous fruit, vegetable and flower market
+        takes place every morning in the Campo dei Fiori, overseen by the
+        statue of philosopher Giordano Bruno. The Counter Reformation burned
+        him alive here in 1600 for his preposterous idea that the universe was
+        infinite, with many more galaxies than ours. An even more famous death
+        occurred at the nearby Piazza del Biscione, more precisely the
+        restaurant Da Pancrazio, whose cellar shelters ruins of Pompeii’s
+        Theater where Julius Caesar was assassinated.
+        Only with a special appointment can you visit the glorious
+        Palazzo Farnese, built by Antonio da Sangallo the Younger,
+        Michelangelo, and Giacomo della Porta. Begun in 1514, it now houses the
+        French Embassy. Only the inner courtyard of Rome’s finest Renaissance
+        palace is accessible to the public, but its grand portico and the
+        handsome stuccoed vestibule leading to it make it well worth a visit. A
+        privileged few get in to see the ceremonial dining room’s fabulous
+        frescoes by Annibale Carracci. Since 1871, the French pay a rent of one
+        lira every year and provide a palace in Paris as Italy’s embassy.
+        Narrow streets southeast of the Campo de’ Fiori take you to
+        the Jewish Ghetto near the ruins of the ancient Roman Theater of
+        Marcellus (Teatro di Marcello), architectural model for the Colosseum.
+        Jews have been a permanent feature of Roman life for over 2,500 years
+        but were forced into a ghetto in the 16th century. A small Jewish
+        community still lives nearby around the Via del Portico d’Ottavia. The
+        hefty neo-Babylonian synagogue (inaugurated in 1904), with a small
+        museum of Jewish history next door, is by the river bank.
+        Classical Rome
+        The nucleus of classical Rome is around the Colosseum, with
+        the Forum to the northwest and the Baths of Caracalla to the south.
+        Don’t be daunted — even the best-informed scholars find the monumental
+        relics difficult to decipher — the mystery itself is more than half the
+        charm of these vestiges of a vanished world. Take them in your stride,
+        avoid the midday sun in the shadeless Forum, and finish your visit with
+        a picnic and siesta on the Palatine. Even if you’re not an archaeology
+        buff who wants to understand the meaning of every stone, it’s worth at
+        least an hour or two to stand among the debris of an empire and wonder
+        whether Fifth Avenue, Piccadilly, the Champs-Elysées, or Red Square
+        will look any better 2,000 years from now.
+        Of Rome’s countless inspirational churches and palazzos, it
+        is the Colosseum — what Byron called “the gladiator’s bloody
+        circus”—that is the symbol of the city’s eternity. Built in a.d. 80,
+        the four-tiered elliptical amphitheater seated 50,000 spectators.
+        Flowing in and out of 80 arched passageways known as vomitoria,
+        aristocrats and plebs alike came to see blood: bears, lions, tigers,
+        and leopards starved into fighting each other and against criminals,
+        war captives, and (according to some historians) Christians.
+        Gladiators, once criminals and slaves but later professional warriors,
+        fought one another to the crowds’ cries of Jugula! (“Slit his throat! ”
+        ).
+        For their churches and private palaces, popes and princes
+        have stripped the Colosseum of its precious marble, travertine, and
+        metal. In the arena’s basin, they have left a ruined maze of cells and
+        corridors that funnelled men and beasts to the slaughter. The horror
+        has disappeared beneath the moss and what remains is the thrill of the
+        monument’s endurance. As an old Anglo-Saxon prophecy goes: “While
+        stands the Colosseum, Rome shall stand; when falls the Colosseum, Rome
+        shall fall; and when Rome falls, with it shall fall the world. ” There
+        is reason to believe it shall stand forever, a massive top-to-toe
+        restoration completed in 1999 has it looking rejuvenated and
+        soot-free.
+        The nearby Arch of Constantine celebrates the
+        fourth-century emperor’s battlefield conversion to Christianity. A
+        cost-conscious Senate took fragments from monuments of earlier rulers
+        Trajan, Hadrian, and Marcus Aurelius to decorate the arch.
+        Immediately northeast of the Colosseum is the Domus Aurea,
+        the fabulous villa with extensive gardens built by the Emperor Nero,
+        who spent just a few years in his “Golden House” before killing himself
+        in a.d. 68. It was reopened to the public in 1998 after 15 years of
+        renovation work. On a site once 25 times the size of the Colosseum,
+        only 30 rooms of the 250-room palace can be visited, and by guided tour
+        only.
+        With an exhilarating leap of the imagination, you can stand
+        among the columns, arches, and porticoes of the Roman Forum and picture
+        the civic, commercial, and religious hub of the great city, the first
+        in Europe to house a million inhabitants. Earthquake, fire, flood, and
+        the plunder of barbarians and Renaissance architects reduced the area
+        to a muddy cow pasture until the excavations of the 19th century.
+        Today, a detailed map and portable sound-guides rented at the entrance
+        (on the Via dei Fori Imperiali) will make sense of the apparent
+        confusion and help you trace the layout of palaces, temples, and market
+        halls.
+        Part of the brick-built Curia, home of the Roman Senate,
+        still stands. Steps nearby lead underground to the Lapis Niger, a black
+        marble pavement laid by Julius Caesar over the presumed grave of
+        Romulus, the city’s founder. To the south of it are remains of the
+        Basilica Julia law court and the Rostra orators’ platform from which
+        Mark Antony informed the people of Caesar’s assassination. Countless
+        Renaissance and Baroque sculptors have drawn inspiration from the
+        friezes on the triple Arch of Septimius Severus (honoring a
+        third-century emperor who died in York, England, the northernmost
+        boundary of the empire).
+        The Temple of Saturn doubled as state treasury and center
+        of the December debauchery known as the Saturnalia, pagan precursor of
+        Christmas. In the circular Temple of Vesta, the sacred flame
+        perpetuating the Roman state was tended by six Vestal Virgins who, from
+        childhood, observed a 30-year vow of chastity on fear of being buried
+        alive if they broke it. At the end of the Via Sacra, the Arch of Titus
+        commemorates the sack of Jerusalem in a.d. 70.
+        Most impressive monument of the Imperial Forums, built as
+        an adjunct to the Roman Forum in honor of Julius Caesar, Augustus,
+        Trajan, Vespasian, and Domitian, is the 30-m- (100-ft-) high Trajan’s
+        Column (a.d. 113). Celebrating Trajan’s campaigns against the Dacians
+        in what is now Romania, the minutely detailed friezes spiraling around
+        the column constitute a veritable textbook of Roman warfare utilizing
+        some 2,500 figures. St. Peter’s statue on top replaced that of the
+        emperor’s in 1587.
+        South of the Roman Forum, a slope leads up to the Palatine
+        Hill, Rome’s legendary birthplace and today a romantic garden, dotted
+        with toppled columns among the wild flowers and spiny acanthus shrubs.
+        Only rows of cypress trees and summer pavilions remain from the more
+        formal botanical gardens laid out here in the 16th century by the
+        Farnese family. A small museum reopened here in 1998. From its grassy
+        knolls, enjoy the fine view back over the Colosseum or southward over
+        the great Circus Maximus, where chariot races were held for crowds of
+        up to 200,000.
+        A kilometer (about half a mile) south of the Colosseum, the
+        huge third-century Baths of Caracalla (Terme di Caracalla) were built
+        for 1,600 people to bathe in considerable style and luxury. The baths
+        and gymnasia were of alabaster and granite, decorated with statues and
+        frescoes. Public bathing was a prolonged social event as merchants and
+        senators passed from the calidarium (hot room) to cool down in the
+        tepidarium and frigidarium. Until 1994 the stage for spectacular
+        open-air operas in the summer, the calidarium was vast enough for the
+        unique setting of Verdi’s “Aida” and its processions of elephants,
+        camels, and endless cast. Rumors persist that the performances will
+        resume again: stay tuned.
+        South of the baths begins the Old Appian Way (Via Appia
+        Antica), built in 312 b.c. for the Roman legions who marched to coastal
+        Brindisi to set sail for the Levant and North Africa. On either side
+        lie the ruins of sepulchres of 20 generations of patrician families.
+        The 17th-century chapel of Domine Quo Vadis marks the site where St.
+        Peter, fleeing Nero’s persecution in Rome, is said to have encountered
+        Christ. Farther along the Via Appia are three of Rome’s most celebrated
+        catacombs, including those of St. Callisto, the largest of some 50
+        underground Christian cemeteries.
+        The Vatican
+        The power of Rome endures both in the spirituality evoked
+        by every stone of St. Peter’s Basilica and in the almost physical awe
+        inspired by the splendors of Vatican City. At their best, the popes and
+        cardinals replaced military conquest by moral leadership and
+        persuasion; at their worst, they could show the same hunger for
+        political power and worldly wealth as any caesar or grand duke. A visit
+        to the Vatican is an object lesson for faithful and sceptic alike.
+        Named after the hill on which it stands and which in the
+        Middle Ages was surrounded by a malarial swamp, the Vatican has been a
+        papal residence for over 600 years, but a sovereign state independent
+        of Italy only since the Lateran Treaty signed by Mussolini in 1929.
+        If you have the time, try to visit St. Peter’s Basilica and
+        the Vatican Museums on separate days to avoid fatigue and visual
+        overload. Check opening times: it is anyone’s guess if the generously
+        extended hours for the Jubilee Year 2000 will be kept in effect.
+        To appreciate the unique panorama of St. Peter’s Basilica
+        and its 1 sq km piazza (0.4 sq mile), approach it by foot as history’s
+        countless pilgrims have. Cross at the beautiful Sant’Angelo Bridge, one
+        of 20 crossing the Tiber River. Adorned by ten angel sculptures by
+        Bernini and his studio, it arrives at the Castel Sant’Angelo,
+        originally built as Hadrian’s mausoleum in a.d. 139. Its name derives
+        from Pope Gregory’s vision of the Archangel Michael — now represented
+        by a statue on top — heralding the end of a plague in 590. It was
+        sixth-century barbarians who commandeered the massive round brick pile
+        as a fortress, using ancient statues as missiles to hurl on the heads
+        of their enemies below. Linked to the Vatican by a thick-walled
+        passage, it served as a hideout for popes in times of danger, notably
+        Pope Clement VII, who holed up here for a month during the sack of Rome
+        by Habsburg troops in 1527 (see page 27). The Papal Apartments are a
+        strong contrast to the dungeons, both open to the public, where
+        philosopher and monk Giordano Bruno and sculptor-goldsmith Benvenuto
+        Cellini were once imprisoned.
+        In St. Peter’s Square (Piazza San Pietro), Bernini has
+        performed one of the world’s most exciting pieces of architectural
+        orchestration. The sweeping curves of the colonnades reach out to the
+        unending stream of pilgrims from Rome itself and the whole world, urbi
+        et orbi, to take them into the bosom of the church beyond. In a rare
+        opportunity for concentrated effort by one man on such a gigantic
+        project, Bernini completed the 284 travertine columns, 88 pilasters,
+        and 140 statues of the saints in just 11 years, from 1656 to 1667.
+        Stand on either of the circular paving stones set between the square’s
+        twin 17th-century fountains and the red granite Egyptian obelisk to
+        appreciate the harmony of the quadruple rows of Doric columns, so
+        perfectly aligned that they seem like a single row. The purity of
+        Bernini’s work here refutes the popular conception of Baroque as being
+        nothing but overblown extravagance.
+        St. Peter’s Basilica is the largest of all Roman Catholic
+        churches and by any standards a grandiose achievement, but it
+        inevitably suffered from the competing visions of all the architects
+        called in to collaborate — Bramante, Giuliano da Sangallo, Raphael,
+        Baldassare Peruzzi, Michelangelo, Giacomo Della Porta, Domenico
+        Fontana, and Carlo Maderno — each adding, subtracting, and modifying,
+        often with a pope looking over his shoulder.
+        From 1506 to 1626, it changed from the simple ground plan
+        of a Greek cross, with four arms of equal length, as favored by
+        Bramante and his arch-enemy Michelangelo, to the final form of
+        Maderno’s Latin cross extended by a long nave, as demanded by the popes
+        of the Counter-Reformation. One result is that Maderno’s porticoed
+        façade and nave obstruct a clear view of Michelangelo’s dome from the
+        square.
+        The church’s dimensions are impressive: 212 m (695 ft)
+        exterior length, 187 m (613 ft) inside length; 132 m (435 ft) to the
+        tip of the dome (diameter 42.45 m/139 ft).
+        As you go in, notice the keys of St. Peter inlaid in the
+        doorway paving. Set in the floor by the central door is the large round
+        slab of red porphyry where King Charlemagne knelt for his coronation as
+        emperor in the year 800 (see page 20).
+        You’ll find the basilica’s most treasured work of art,
+        Michelangelo’s sublime Pietà — Mary with the dead Jesus on her lap — in
+        its own chapel to the right of the entrance. The Florentine artist was
+        just 25, and justly proud enough to append his signature (the only
+        surviving example), visible on the Madonna’s sash . Since a religious
+        fanatic attacked it with a hammer in 1972, the statue is protected by
+        bullet-proof glass. But reverence can also cause damage: on the
+        13th-century bronze statue of St. Peter near the main altar, attributed
+        to Florentine architect-sculptor Arnolfo di Cambio, the lips and
+        fingers of countless pilgrims have worn away the toes of its right
+        foot.
+        Beneath the dome, Bernini’s great baldacchino (canopy),
+        cast out of bronze beams taken from the Pantheon’s porch (see page 51),
+        soars above the high altar. It was built right over St. Peter’s tomb
+        and reserved exclusively for the pope’s mass. In the apse beyond, the
+        Baroque master gives full vent to his exuberance with his bronze and
+        marble Cathedra of St. Peter, throne of the Apostle’s successors.
+        It should come as no surprise that, as the greatest patron
+        that painters, sculptors, and architects have ever known, the Catholic
+        Church should house in its headquarters, one of the world’s richest
+        collections of art. The 7 km (4 miles) of rooms and galleries of the
+        Vatican Museums are made up of eight museums, five galleries, the
+        Apostolic Library, the Borgia Apartments, the Raphael Stanze (or
+        Rooms), and the incomparable Sistine Chapel. Shuttle buses run
+        regularly from St. Peter’s Square to the museum entrance and back,
+        otherwise a 20-minute walk.
+        If you want at all costs to avoid the Sistine’s day-long
+        crowds, go there first thing in the morning (don’t forget your
+        binoculars for details on the ceiling). In any case, you can’t miss
+        it — arrows indicate color-coded itineraries within the museum that
+        showcase the myriad marvels to see en route, a remarkable degree of
+        which is overlooked by time-restricted visitors on a mission.
+        With the booty from the ruthless dismantling of ancient
+        monuments to make way for the Renaissance city in the 16th century, the
+        Pio-Clementino Museum has assembled a wonderful collection of Roman and
+        Greek art. Most celebrated is the tortured Laocoön group (from Rhodes,
+        first century b.c. –first century a.d. ), only recently returned more
+        closely to its pristine state by the removal of one statue’s
+        outstretched arm added by over-zealous 16th-century “restorers”).
+        Pope Julius II took a calculated risk in 1508 when he
+        called in a relatively untried 26-year-old to do the interior
+        decoration of his new apartments. The result was the four Raphael Rooms
+        (Stanze di Raffaello). In the central Stanza della Segnatura are the
+        two masterly frescoes, Dispute over the Holy Sacrament and the famous
+        School of Athens, confronting theological with philosophical wisdom.
+        The Dispute unites biblical figures with historical pillars of the
+        faith such as Pope Gregory and Thomas Aquinas, but also painter Fra
+        Angelico and the divine Dante. At the center of the School, Raphael is
+        believed to have given the red-coated Plato the features of Leonardo da
+        Vinci, while portraying Michelangelo as the thoughtful Heraclitus,
+        seated in the foreground. Raphael himself appears in the lower
+        right-hand corner.
+        In stark contrast to Raphael’s grand manner, seek out the
+        gentle beauty of Fra Angelico’s frescoes in the Chapel of Nicholas V
+        (Cappella del Beato Angelico). The lives of saints Lawrence and Stephen
+        are depicted in delicately subdued pinks and blues.
+        The richly decorated Borgia Apartments contain
+        Pinturicchio’s frescoes with portraits of the Spanish Borgia Pope
+        Alexander VI and his notorious son Cesare and daughter Lucrezia, and
+        leads into the collection of modern religious artwork opened in 1973 by
+        Paul VI. The latter includes Rodin bronzes, Picasso ceramics, Matisse’s
+        Madonna sketches, and designs for ecclesiastical robes and, rather
+        unexpectedly, a grotesque Francis Bacon pope.
+        But nothing can prepare you for the visual shock of the
+        Sistine Chapel (Cappella Sistina), built for Sixtus IV in the 15th
+        century. Restored to its original colors after a controversial ten-year
+        restoration finished in 1990, the brightness and freshness of the
+        frescoes is overwhelming. Despite the distraction of the constant
+        crowds (quiet is requested), visitors seem to yield to the power of
+        Michelangelo’s ceiling, and his Last Judgement (restored in 1994). The
+        other wall frescoes by Botticelli, Pinturicchio, Ghirlandaio, and
+        Signorelli are barely given attention. In this private papal chapel,
+        where cardinals hold their conclave to elect a new pope, the glory of
+        the Catholic Church achieves its finest artistic expression.
+        The chapel portrays nothing less than the story of man, in
+        three parts: from Adam to Noah; the giving of the Law to Moses; and
+        from the birth of Jesus to the Last Judgment. Toward the center of
+        Michelangelo’s ceiling, you’ll make out the celebrated outstretched
+        finger of man’s creation, filled out by the drunkenness of Noah, the
+        turmoil of the Flood. But most overwhelming of all is the impression of
+        the whole — best appreciated looking back from the bench by the
+        chapel’s exit.
+        On the chapel’s altar wall is Michelangelo’s tempestuous
+        Last Judgment, begun 23 years after the ceiling’s completion in 1512,
+        when he was 60 and imbued with deep religious soul-searching. An almost
+        naked Jesus dispenses justice more like a stern, even fierce Classical
+        god-hero than the conventionally gentle biblical figure. It is said
+        that the artist’s agonizing self-portrait can be made out in the flayed
+        skin of St. Bartholomew, to the right below Jesus.
+        Amid all the Vatican’s treasures, the 15 rooms of the
+        Picture Gallery (Pinacoteca Vaticana), in a separate wing of the
+        palace, get short shrift. This collection of nine centuries of
+        paintings includes important works by Giotto, Fra Angelico, Perugino,
+        Raphael’s Transfiguration (his last great work), Leonardo da Vinci’s
+        unfinished St. Jerome, Bellini’s Pietà, and Caravaggio’s Descent from
+        the Cross.
+        The neighborhood south of the Vatican, Trastevere,
+        literally “across the Tiber,” has long been renowned as the most
+        popular quarter of Rome. Here, ordinary people that consider themselves
+        the original citizens uphold age-old traditions and customs (much like
+        the Cockneys in London). It is good to wander among the narrow streets
+        and markets to sample the authentic life of the city, highlighted by
+        the Noantri (“We Others”) street festival of music, food, and
+        fireworks, during the last two weeks of July. Another sort of festival
+        atmosphere prevails every Sunday, when the Porta Portese section of
+        Trastevere hosts Rome’s liveliest and largest flea market. The stalls
+        are filled with everything from vintage clothing to the occasional
+        valuable antique.
+        Inevitably, “popular” and “authentic” became chic and the
+        ambience is now somewhat contested by higher rents and the change in
+        character that guarantees. But the true Trasteverini hang on, mainly in
+        the area immediately around Santa Maria in Trastevere, reputedly the
+        oldest church in the city. Its foundation may date back to the third
+        century, but the present structure is the work of Pope Innocent II,
+        himself a Trasteverino, around 1140. It is known for its wonderful
+        Byzantine-influenced façade and the interior’s pavements and mosaic of
+        Mary enthroned with Jesus decorating the domed ceiling of the apse. The
+        liveliest fruit and vegetable market is to be found on Piazza di San
+        Cosimato.
+        Other Museums
+        The largest collection of Etruscan art in Italy can be
+        found in the 16th-century Villa Giulia in the northwest area of the
+        Villa Borghese park. Room after room is filled with objects from the
+        tombs of this little understood pre-Roman people: shields, weapons, and
+        chariots; exquisite gold and silver jewelry; and decorative ceramic
+        works. The museum’s highlight is a life-size, sixth-century b.c.
+        terracotta sculpture of a reclining couple that was used as the lid of
+        a sarcophagus.
+        The Borghese Gallery, opened in 1997 after an extensive
+        14-year renovation, is housed in a handsome Baroque villa inspired
+        originally by Hadrian’s Villa at Tivoli (see page 69), but with its
+        Italian formal gardens now transformed into an English-style landscaped
+        park. One of Italy’s loveliest and most important small museums, its
+        highlights include some outstanding sculptures by Bernini and Canova
+        (whose portrayal of Napoleon’s sister as a reclining Venus is arguably
+        the museum’s most famous attraction), as well as paintings by Raphael,
+        Correggio, Titian, Caravaggio, Botticelli, Rubens, Dürer, and
+        Cranach.
+        The Capitoline Museums, in the twin palaces of the
+        Campidoglio (see page 50), have extensive collections of sculpture
+        excavated from ancient Rome, particularly in the Palazzo Nuovo. In the
+        Palazzo dei Conservatori is the most celebrated piece, the superb
+        Etruscan bronze Capitoline She-Wolf (Lupa Capitolina), symbol of the
+        city. The wolf dates from around the fifth century b.c. , but the
+        little Romulus and Remus that she is suckling are actually Renaissance
+        additions by Pollaiuolo. The top-floor Capitoline Picture Gallery
+        (Pinacoteca Capitolina) has important Venetian works by Bellini,
+        Titian, Tintoretto, Lotto, and Veronese, as well as a fine Rubens
+        Romulus and Remus and Caravaggio’s St. John the Baptist.
+        Alternatively known as the Palazzo Barberini or the
+        National Gallery of Antique Art (Galleria Nazionale d’Arte Antica) (on
+        the Via delle Quattro Fontane), another architectural battleground for
+        arch-rivals Borromini and Bernini, is worth a visit as much for its
+        splendid Baroque décor as for its collection of 13th–17th-century
+        paintings. They come together in the palace’s Salone or Great Hall with
+        Pietro da Cortona’s dazzling illusionist ceiling fresco, Triumph of
+        Divine Providence. Notable in the collections are a Fra Angelico
+        triptych, Raphael’s La Fornarina (though the authorship is disputed),
+        and works by Titian, Tintoretto, and El Greco.
+        New on the scene is the vast Palazzo Doria Pamphili off the
+        Piazza Venezia. The private collection of the important Doria family
+        includes a number of masterpieces by artists of the 15th to the 17th
+        century, particularly Annibale Carracci and Brueghel the Elder.
+        Other Churches
+        It’s impossible to even count all of the delightful
+        churches worth visiting in Rome (unofficial counts hover at 250), many
+        of which are commonly stumbled on by accident. We suggest just three
+        within easy reach of the Via Cavour thoroughfare leading from the main
+        railway station (Stazione Termini).
+        Originally built in the fourth century on the Esquiline
+        Hill site of a Roman temple to the goddess Juno, Santa Maria Maggiore
+        is the largest and most splendid of the churches dedicated to the
+        Virgin Mary. Christmas time is especially popular here when pilgrims
+        come to admire relics of the holy crib from Beth­lehem. In the Oratory
+        of the Crib (Oratorio del Presepio) are the moving 13th-century
+        sculptures of Joseph, the Three Kings, the ox, and the ass, by Arnolfo
+        di Cambio (Mary and the child Jesus are 16th-century additions). The
+        most spectacular art treasures of the church are its gorgeous Byzantine
+        mosaics, glittering Old Testament scenes high on the walls (don’t
+        forget the binoculars), and a triumphant Mary and Jesus enthroned in
+        the apse over the high altar. The coffered Renaissance ceiling glitters
+        with the gold of the first shipments from the New World.
+        In a nearby side street, Santa Prassede is unprepossessing
+        from the outside but enchanting in the intimacy of its interior. The
+        delicate ninth-century mosaics of Jesus and four angels make the Chapel
+        of St. Zeno the city’s most important Byzantine monument. To the right
+        of the chapel is a fragment of rare jasper said to come from the column
+        to which Jesus was tied for his flagellation. Notice the fine mosaic of
+        Jesus and the New Jerusalem over the chancel.
+        San Pietro in Vincoli (St. Peter in Chains) might not
+        attract a second look if it didn’t contain one of the greatest of
+        Michelangelo’s sculptures, his formidable Moses. Intended for St.
+        Peter’s Basilica as part of Michelangelo’s botched project for Pope
+        Julius II’s tomb, the statue of the great biblical figure sits in
+        awesome majesty. You can imagine how grandiose the original plan must
+        have been when you realize that Moses was supposed to be one of 40
+        figures adorning the tomb. The “horns” on his head continue a
+        traditional medieval mistranslation of the Hebrew for halo-like rays of
+        light. On each side, the comparatively passive figures of Jacob’s
+        wives, a prayerful Rachel and melancholy Leah, were the last completed
+        sculptures of Michelangelo.
+        Lazio
+        The excursions to be made today into the Lazio hinterland
+        around Rome are those that ancient Romans themselves made to vacation
+        homes by the sea or nearby lakes.
+        Tivoli
+        Follow the old Roman chariot road (repaved) of Via
+        Tiburtina 30 km (19 miles) east of the capital to the haunting ruins of
+        Hadrian’s Villa (Villa Adriana), near the picturesque town of Tivoli,
+        at the foot of the Sabine Hills. Sprawling across 70 hectares (173
+        acres), this retirement hideaway of the great emperor-builder was
+        designed to recapture some of the architectural marvels of his empire,
+        especially the Greece he loved above all else — a travel notebook for
+        his old age. Barbarians and museum curators have removed most of the
+        villa’s treasures, but a stroll through the remaining pillars, arches,
+        and mosaic fragments in gardens running wild among the olive trees,
+        cypresses, and pines can be marvelously evocative of a lost world. To
+        get a clear sense of the original, start with the villa’s excellent
+        scale model. The monumental baths, separate Latin and Greek libraries,
+        Greek theater, temples, and pavilions together make up the home of a
+        man who drew no distinction between the pleasures of mind and body. In
+        the center, the enchanting Villa ­dell’Isola, a pavilion surrounded by
+        a little reflecting pool and circular portico, epitomizes all the magic
+        of the place.
+        In Tivoli itself, overlooking the Roman plain, the Villa
+        d’Este is a 16th-century counterpart, celebrating all the extravagance
+        of the late Renaissance. From the home of Cardinal Ippolito d’Este,
+        guests can look down at the terraced gardens, the real reason for
+        Tivoli’s fame and your visit: alleys of cypresses and soaring fountains
+        (500 in all, including Bernini’s Bicchierone), grottoes, waterfalls,
+        reflecting pools, and everywhere the cool sound of rushing water.
+        Alban Hills and Castel Gandolfo
+        The region immediately southeast of Rome is known locally
+        as the Castelli Romani (Roman Castles) for the fortified hilltop
+        refuges built during the medieval civil wars. Today it’s just the
+        summer heat that drives the Romans out on day-trips to the vineyards of
+        the Alban hills and lakes. The country villages of Frascati,
+        Grottaferrata, Marino, and Rocca di Papa make delightful stops, not
+        least of all for a cool glass of their white wine, especially during
+        the autumn grape-harvest festivals. The pope has his summer palace at
+        Castel Gandolfo, on the shores of Lake Albano. As his health is
+        failing, his usual Wednesday and Sunday blessings from mid-July to
+        early September are no longer guaranteed.
+        Tarquinia and Northern Lazio
+        The A12 autostrada and the old Via Aurelia (which ends up
+        in Arles in French Provence) take you to Tarquinia. Most important of
+        the original 12 towns of the Etruscan confederation, the town dominated
+        Rome in its heyday of the seventh and sixth centuries b.c. Today, the
+        paintings and sculptures found in its necropolis of over 5,700 tombs
+        provide fascinating evidence of the brilliant Etruscan civilization for
+        archeology buffs. Visits to the tombs outside of town are organized
+        from the National Museum, housed in the fine 15th-century
+        Gothic-Renaissance Palazzo Vitelleschi as you enter Tarquinia. The
+        museum exhibits sarcophagi, Etruscan and imported Greek vases, and some
+        of the best wall-paintings — all in reconstructed tombs. Displayed in a
+        room by itself, the prize of the collection is the Winged Horses
+        sculpture from Tarquinia’s Ara della Regina Temple.
+        Tuscania is a quiet little fortified town, recovering now
+        from an earthquake in 1971 that luckily did not harm its two Romanesque
+        churches on the eastern outskirts (check with the tourist office on
+        Piazza Basile for erratic hours). Built from the eighth to the 12th
+        centuries, San Pietro stands at the ba ck of a grassy courtyard with
+        Etruscan sarcophagi, beside two crumbling medieval towers. The sober
+        interior has Byzantine-style frescoes, an 11th-century altar canopy,
+        and a crypt built on Etruscan and ancient Roman pillars. The Romanesque
+        tower and rose window of Santa Maria Maggiore’s façade have a similar
+        simple beauty.
+        In the restful charm of its medieval quarters, Viterbo
+        makes a good overnight stop. The oldest neighborhood, with narrow
+        streets and little market squares, is around the Via San Pellegrino. On
+        the equally attractive Piazza San Lorenzo, the Palazzo Papale has an
+        impressive 13th-century Gothic loggia, opposite the Cathedral’s
+        intriguing mixture of Gothic campanile (bell tower) and Renaissance
+        façade with Romanesque interior.
+        Sardinia (Sardegna)
+        The Mediterranean’s second largest island (Sicily being
+        the largest) is worth a vacation all to itself — and much more detailed
+        treatment than follows. Those curious to get a feel for its atmosphere
+        (rarely first-time visitors to Italy) should consider summertime stays
+        at small seaside resorts (off-season visits will fail to capture its
+        allure), meandering drives along its impressive coastline, and a couple
+        of excursions into the little-visited hinterland.
+        Prehistoric man dotted the island with his mysterious
+        cone-shaped nuraghi houses and watchtowers before it was colonized by
+        Cretans, Phoenicians, Carthaginians, and Romans. Later, the island
+        became part of the commercial empires of Pisa, Genoa, and the Spanish,
+        and was annexed in 1718 by the dukes of Savoy. Malarial mosquitoes and
+        repressive feudalism restrained the island’s development until the 19th
+        century. Since then it has undergone a rapid industrialization balanced
+        today by renewal of its cattle farming. Its environmentally-sensitive
+        development of the Costa Smeralda is a mecca for Europe’s yachting set
+        and August sees its limited five-star hotels booked months in
+        advance.
+        Cagliari
+        The island’s capital and main port is a largely modern
+        city, but with a Spanish flavor to its older quarters up on the hill.
+        The Archaeological Museum includes important bronze statues of warriors
+        and priests found in prehistoric tombs. The much renovated cathedral
+        has two superbly carved 12th-century pulpits, originally commissioned
+        for the cathedral in Pisa. Before heading for the open road, try the
+        excellent local cuisine, including both Spanish-style fish stews and
+        Genoese pasta dishes.
+        The winding Cagliari-Muravera road across the plunging
+        ravines of the Sarrabus mountains to the coast is one of the most
+        spectacular drives on the whole island.
+        Continue up the coast to Lanusei and head inland across
+        the rugged Gennargentu mountains, covered with dense forests of cork
+        oak and chestnut trees. Farther north, just off the Nuoro-Dorgali road
+        is the secluded site of Serra Orrios, a well-preserved prehistoric
+        village (signposted Villaggio Nuragico). A short walk along a marked
+        path through the fields takes you to a group of drystone houses with
+        two temples and circular ramparts in a lovely setting of eucalyptus and
+        olive trees. Archaeologists have located some 7,000 of these nuraghi
+        structures around the island, most of them flattened cone towers
+        believed to be parts of fortified citadels.
+        Costa Smeralda
+        The glittering Emerald Coast on the northeast tip of the
+        island is one of Italy’s smartest resort areas, with beautiful beaches,
+        five-star hotels, sports complexes, and exclusive marinas for yachts
+        and motor launches. It stretches around bays and rocky inlets from
+        Olbia in the east to the promontory of La Maddalena.
+        Porto Cervo is the coast’s fashionable center, but Baia
+        Sardinia competes with its craggy coastline. More exclusive is the
+        little luxury resort island and fishing village of La Maddalena, a
+        15-minute ferry-ride from Palau. It is in fact the principal island of
+        an archipelago of 14, most of them little more than piles of rocks.
+        Linked to La Maddalena by a 7–km- (4–mile-) long causeway,
+        the isle of Caprera was the last home of Giuseppe Garibaldi, military
+        leader of the Risorgimento movement for Italian unity (see page 32).
+        The house where he died in 1882 (his tomb is nearby) is now a museum,
+        practically a sanctuary, where devout patriots refer to him not by
+        name, but as l’Eroe, “the Hero. ”
+        The north coast road makes an enjoyable excursion along
+        the dunes and pine groves lining the Gulf of Asinara. The fortress-town
+        of Castelsardo stands high on a spectacular promontory overlooking the
+        gulf. Inside its 16th-century cathedral, you hear the sea crashing on
+        the rocks directly below the foundations. At Porto Torres, visit the
+        important 11th-century Pisan Romanesque church of San Gavino. Its
+        façade was never finished, its interior of a noble simplicity. Some of
+        the pillars come from an ancient Roman temple, with two Corinthian
+        capitals serving as a lectern.
+        Alghero
+        This quiet little seaside resort on the northwest coast
+        has a pleasant Catalan flavor to its older quarters around the
+        cathedral. Take a sunset stroll along the 16th-century Spanish
+        ramparts.
+        There’s good fishing to be had in the nearby bay of Porto
+        Conte, and the Palmavera nuraghi citadel is well worth a visit. On the
+        bay’s southwestern promontory is the fascinating Grotta di ­Nettuno
+        (Neptune’s Grotto). Guided tours of these subterranean caverns with
+        their dramatic stalactites and stalagmites are organized by boat from
+        Alghero or on foot directly at the site, down a steep stairway in the
+        cliffs.
+        TUSCANY AND UMBRIA
+        Light is the secret of Tuscany’s magic. In that apparently
+        miraculous collision of imagination and intellect that sparked the
+        Renaissance in 15th-century Florence, its painters and architects had
+        the constant inspiration of the dramatic changes in Tuscan light from
+        dawn to dusk. And more than anywhere else in the country, Tuscany and
+        neighboring land-locked Umbria present the ideal green Italian
+        landscape, dotted with stalwart hilltop towns, where cypress-tree
+        sentinels watch over groves of twisted olive groves and vineyards
+        blanket the gentle rolling hills.
+        Florence lies at the heart of the northern Apennines, in a
+        basin of the Arno river which runs out to Pisa and the sea. Siena, its
+        proud historic rival, dominates the Tuscan hill towns to the south,
+        while the university town of Perugia and the Assisi of St. Francis are
+        the keys to Umbria’s luminous beauty.
+        With some careful timing, modern visitors can capture a
+        glimpse of that miracle of light. Arrive early in the morning for your
+        first look across the hills from the grey-stone towers of San Gimignano
+        (a “medieval Manhattan”), or come to Siena’s Piazza del Campo at
+        sunset. The dazzling white marble of Pisa’s Duomo and leaning campanile
+        is most breathtaking in the noonday sun, but late afternoon is the
+        blessed moment for the brilliant mosaic façade of Orvieto’s
+        cathedral.
+        Florence (Firenze)
+        Despite the dead heat and humidity of summer Florence,
+        with the magnificence of its monuments and museums, it is packed
+        nonetheless. Its people are more reserved and less seductive than
+        Romans or Nea­po­­litans in the South. This said, Florence remains one
+        of the world’s great tourist meccas and boasts a panoply of
+        architecture, history, and artwork in quantities not to be found
+        elsewhere in the world.
+        Our itineraries divide the city’s heart into four
+        quarters: from the Duomo north to Piazza San Marco; from the Piazza
+        della Signoria, its Palazzo Vecchio and the Uffizi Galleries east to
+        Piazza Santa Croce; from the Mercato Nuovo west to Piazza Santa Maria
+        Novella; and the southern “Left Bank” of the Arno River around the
+        Pitti Palace and the Piazzale Michelangelo.
+        From the Duomo to Piazza San Marco
+        The Duomo (cathedral), officially Santa Maria del Fiore,
+        proclaims the inordinate but certainly justified civic pride of the
+        Florentines. The very heart of the city’s centro storico, it was begun
+        in 1296 under Arnolfo di Cambio, although the imposing green, white,
+        and rose marble neo-Gothic façade was completed only six centuries
+        later.
+        The first of its glories is the free-standing campanile,
+        designed by the multi-talented Giotto. The 85-m- (267-ft-) tall
+        bell-tower (it’s a 414-stair climb to the top) is decorated on its
+        lower sections by hexagonal bas-reliefs sculpted by Andrea Pisano and
+        Luca della Robbia, based on Giotto’s drawings. Characteristic of the
+        city’s civic consciousness, they portray the Life of Man from Adam’s
+        creation to the rise of civilization through the arts and
+        sciences — music, architecture, metallurgy, and the like — pursued so
+        earnestly by the Florentine guilds that commissioned the work.
+        Originals of Donatello’s sculpture are kept in the cathedral’s own
+        newly renovated museum, Museo dell’Opera del Duomo (Piazza del Duomo,
+        9) as well as Michelangelo’s unfinished Pietà. The dead Jesus in his
+        mother’s arms emphasizes the agony rather than the pathos portrayed by
+        the Pietà in St. Peter’s in Rome (see page 61). Michelangelo originally
+        conceived the group for his tomb and represented himself in the figure
+        of Nicodemus. Flaws in the marble so enraged the artist that he hurled
+        a hammer at it, destroying Christ’s left leg — the left arm has been
+        restored and the rather insipid Mary Magdalen was later added by a
+        pupil.
+        Brunelleschi’s masterpiece, the cathedral’s grandiose
+        terra-cotta cupola, with its eight white stone ribs curving to the
+        marble lantern at the top, is the city’s symbol, visible not only all
+        over Florence but also from far beyond in the Tuscan hills. Completed
+        in 1436, it measures 45.5 m (149 ft) in diameter. The 463 steps to its
+        top climb in comfortable stages to reveal a panorama of the surrounding
+        city, different views of the cathedral’s interior, and fascinating
+        close-ups of the dome’s structure and the 16th-century frescoes
+        restored in 1996. Begun by Giorgio Vasari and finished by his pupil
+        Federico Zuccari, it is the world’s largest depiction of the Last
+        Supper. (Brunelleschi’s original wooden model of the cupola is
+        displayed in the cathedral museum. ) Look for Ghiberti’s bronze shrine
+        below the high altar, as well as his three stained-glass windows on the
+        entrance wall. In the third bay on the north aisle is Paolo Uccello’s
+        statue-like equestrian painting of the 15th-century English mercenary
+        Sir John Hawkwood (unpronounceable for Italians, so known as Giovanni
+        Acuto).
+        The octagonal 12th-century Romanesque baptistery of San
+        Giovanni (St. John) is celebrated as the oldest building in Florence,
+        and for the magnificent bas-reliefs of its three sets of bronze doors.
+        The oldest, facing south and telling the story of John the Baptist,
+        were designed by Andrea Pisano in 1330. A century later, Lorenzo
+        Ghiberti won the competition to design the great north and east doors,
+        devoted respectively to the life of Jesus and scenes from the Old
+        Testament. Michelangelo said the latter, facing the Duomo, were good
+        enough to adorn the entrance to heaven and they have been known ever
+        since as the Doors of Paradise. Among the losing candidates was Filippo
+        Brunelleschi, who thereafter devoted himself entirely to architecture.
+        (In the Bargello, you can compare his bronze model with Ghiberti’s; see
+        page 89) Magnificent Byzantine-style mosaics inside the cupola include
+        scenes from the Creation, Life of St. John, and a Last Judgment and
+        date from the 13th century.
+        The might of the Medici family can be sensed in their
+        massive palazzo, northwest of the cathedral on Via Cavour, the
+        15th-century Palazzo Medici-Riccardi. Now Florence’s prefecture
+        offices, the formidable edifice set the style for the city’s
+        Renaissance palaces. The ground floor originally had an open loggia at
+        the corner for the family banking business. Don’t miss the upstairs
+        chapel for Benozzo Gozzoli’s 15th-century fresco of the Journey of the
+        Magi to Bethlehem. It portrays the Medici clan led by Lorenzo the
+        Magnificent in what is in fact an allegory of an ecumenical council
+        with Pope Pius II in Florence. The Medici family lived here until
+        moving to the Palazzo Vecchio and eventually the Palazzo Pitti.
+        Around the corner is the family church of San Lorenzo
+        designed by Brunelleschi before he designed the Duomo’s cupola. Funds
+        ran out before Michelangelo’s planned façade could embellish the
+        austere barn-like exterior. Inside, you’ll see the Medici family arms
+        set in the floor in front of the altar. Brunelleschi is at his most
+        elegant in the Old Sacristy at the end of the left transept (site of a
+        few Medici tombs), decorated with four Donatello wall-medallions (the
+        artist himself is buried in the left transept). Adjacent to the church
+        is the Laurentian Library (Biblioteca Laurenziana), commissioned in
+        1524 and most known for the graceful cloisters and monumental
+        Michelangelo-designed stairway.
+        Adjoining the church but with a separate outdoor entrance
+        in the back are the Medici Chapels (Cappelle Medicee), monuments to the
+        splendor and decadence of the family dynasty. The Princes’ Chapel
+        (Cappella dei Principi) is a piece of 17th-century Baroque bombast in
+        flamboyant multi-colored marbles, for which the altar was not
+        completed, appropriately enough, until 1939. The summit of Medici power
+        is found in Michelangelo’s superb New Sacristy (Sacrestia Nuova), a
+        one-man show of his unparalleled talents that he worked on from
+        1521–1534. Lorenzo the Magnificent and brother Giuliano lie in simple
+        tombs beneath the sculptor’s Madonna and Child, flanked by lesser
+        artists’ statues of the family patron saints Cosmas and Damian.
+        Michelangelo’s greatest work here is reserved for two minor members of
+        the family, Lorenzo’s grandson, Lorenzo the Duke of Urbino, portrayed
+        as a pensive Roman soldier above two allegorical figures of Dawn
+        (female) and Dusk (male), and his son, Giuliano the Duke of Nemours,
+        more warrior-like above figures of Night (female) and Day (male). The
+        Church of San Lorenzo finds itself surrounded by hundreds of stalls
+        that make up the open-air Mercato San Lorenzo, one of Italy’s largest
+        tourist markets offering good finds and competitive prices.
+        It’s an easy walk to Piazza San Marco and the Dominican
+        Monastery of San Marco, an evocative setting for a museum largely
+        devoted to the paintings of Florentine-born Fra Angelico (1387–1455),
+        who lived here as a monk. Off the cloister, with its ancient cedar
+        tree, is the Pilgrim’s Hospice (Ospizio dei Pelligrini) where some of
+        his finest works are found, notably a Descent from the Cross. In the
+        monks’ cells upstairs, the frescoes of the man historians call Beato
+        (Blessed) Angelico were intended to be inspirational rather than
+        decorative. His celebrated Annunciation faces the top of the
+        stairs — compare the simpler version in cell 3 — while other
+        outstanding works include the mystic Transfiguration in cell 6 and
+        Jesus Mocked in cell 7. In the small refectory is the important
+        Ghirlandaio mural of the Last Supper, a subject traditionally found in
+        monastic dining rooms. The Prior’s Quarters in the second dormitory
+        (cells 12, 13, and 14) were the home of fire-and-brimstone preacher
+        Girolamo Savonarola from 1481 until his death in 1498 (see page 26).
+        You can see some of his belongings, his famous portrait by fellow-monk
+        Fra Bartolomeo, and the picture of his burning at the stake in Piazza
+        della Signoria.
+        As a museum conceived primarily for students of Florentine
+        painting from the 13th to 16th centuries, the Accademia Gallery
+        (Galleria dell’Accademia) (Via Ricasoli, 60) ranks high on Florence’s
+        must-see list. Its major interest is in the seven statues by
+        Michelangelo. Six of them are unfinished — four Prisoners (a.k.a. The
+        Slaves), St. Matthew, and a Pietà — each a fascinating revelation of
+        how Michelangelo released their power from the marble. The Accademia’s
+        uncontested star, the great David (which once stood in the Piazza della
+        Signoria, now substituted by a life-size copy), provides the perfect
+        object lesson of the finished product, a hero infused with all the
+        contained energy needed to hurl that stone at Goliath. Perhaps the most
+        famous piece of sculpture in the Western world, it was carved from a
+        discarded defective column of marble by the artist when he was just 26
+        years old.
+        In the Piazza Sant issima Annunziata, Brunelleschi
+        produced a consummate piece of Renaissance urban planning, a pioneering
+        example of the piazza as stage-set. In the 1440s he designed the
+        gracefully arched loggia and the Ospedale degli Innocenti, the first
+        hospital for foundlings in Europe; swaddled babes are the subject of
+        Andrea della Robbia’s roundels above the arches. Michelozzo’s later
+        Santissima Annunziata church, together with the 17th-century fountains
+        and equestrian statue of Grand Duke Ferdinando, preserve the harmonies
+        of the master’s overall design. Head out of the piazza just north of
+        the Ospedale in the direction of Via della Colonna and the Museo
+        Archeologico, whose important collection of ancient Egyptian, Greek and
+        Etruscan art make it an interesting alternative to Renaissance
+        overload.
+        Piazza della Signoria to Piazza Santa Croce
+        Flanked by some of the city’s most stylish fashion
+        boutiques and shoe stores, the quarter’s main street retains the
+        commercial tradition of its medieval name, Via de’ Calzaiuoli
+        (stocking- and shoe-makers). It connects the Piazza Duomo with the
+        Piazza della Signoria.
+        If the tall rectangular block of Orsanmichele looks to you
+        more like a grain silo than the church it’s supposed to be, that’s
+        because it has been used as both. Formerly an open loggia, it was
+        rebuilt in the early 14th century as a market, and then as a church in
+        1380 converting its Gothic arches to the present ground-floor windows,
+        and adding a granary upstairs. The fortress-like exterior is decorated
+        with 14 niches: to fill them, the major guilds commissioned statues of
+        patron saints from Florence’s greatest talents (replicas now stand in
+        their place). Look for Ghiberti’s vigorous bronze of the city’s patron
+        St. John (east wall, on the Via de’ Calzaiuoli); St. Matthew, the
+        bankers’ tax-collector turned Apostle (west); Donatello’s St. George,
+        the armorers’ dragon-killer (north, a bronze cast of a marble original
+        in the Bargello); St. Mark, whose vividly sculpted robes do credit to
+        the linen-drapers he protects (south); and Nanni di Banco’s outstanding
+        conspiratorial group of Four Crowned Martyrs for the sculptors’ own
+        guild of stonemasons and wood-workers (north). In the mystical pillared
+        interior is Andrea Orcagna’s elaborate 14th-century Gothic tabernacle
+        with a miracle-working icon-like Madonna painted by Bernardo Daddi.
+        Piazza della Signoria is Florence’s civic and social
+        center. Site of the stoic town hall (Palazzo Vecchio or della Signoria)
+        since 1299, the square bustles in all seasons, not least because it
+        leads to the richest of Italy’s art museums, the Uffizi. At the south
+        end of the square is the 14th-century Loggia della Signoria or dei
+        Lanzi, transformed from the city fathers’ ceremonial grandstand into a
+        guardroom for Swiss mercenary Lands­knechte. It shelters Benvenuto
+        Cellini’s bronze masterpiece, Perseus (replaced by a copy in 1998 while
+        undergoing restoration in the Uffizi) brandishing the severed head of
+        Medusa. In one inspired moment, the Renaissance braggart has combined
+        the legendary technical wizardry he loved to show off as a goldsmith
+        with undeniable sculptural beauty.
+        Also in the Loggia, the spiralling Rape of the Sabines of
+        Giambologna (actually a Flemish artist named Jean de Boulogne) is
+        another piece of dazzling virtuosity, donated by the Medici.
+        In a piazza that is an open-air sculpture gallery, more
+        statuary graces the orator’s platform along the Palazzo Vecchio’s sober
+        façade. To the left of its entrance is a copy of Donatello’s Marzocco,
+        Florence’s heraldic lion, next to his bronze of Judith and Holofernes,
+        which always made the Medici uneasy with its theme of a tyrant
+        decapitated. Getting little attention is 16th-century Bandinelli’s
+        clumsy Hercules and Cacus, standing as it does in the shadow of
+        Michelangelo’s magnificent David; this life-size copy was placed here
+        in 1873. Standing against a hostile world of cruel Philistines,
+        Florentines loved to identify with the beauty and courage of the poetic
+        young giant-killer.
+        A commemorative plaque (near the Baroque fountain)
+        embedded in the piazza marks the spot where Savonarola was executed
+        (see page 26).
+        In gentle contrast to the austere Italian Gothic exterior
+        of the Palazzo Vecchio by Arnolfo di Cambio (architect of the Duomo),
+        Vasari added ornate stucco and frescoes to the first inner courtyard
+        for a Medici wedding in the 1560s (the palazzo served briefly as a
+        Medici residence until they moved across the river to the Palazzo
+        Pitti). A copy of Verrocchio’s delightful bronze cherub tops the
+        porphyry fountain in the center. Upstairs, the Salone dei Cinquecento
+        was built in 1495 for the short-lived Florentine Republic before
+        serving as Duke Cosimo’s throne room and, three centuries later, the
+        chamber of Italy’s first national parliament. The décor celebrates
+        Florentine power — Vasari frescoes of victories over Siena and Pisa and
+        Michelangelo’s Victory statue. On the second floor, the Sala dei Gigli
+        (Hall of the Lilies) is brilliantly decorated in blues and golds with
+        Florentine heraldry and vivid Ghirlandaio frescoes of Roman and early
+        Christian history. It adjoins the Chancery (Cancelleria) where Niccolò
+        Macchiavelli served as secretary to the Florentine Republic. Any
+        world-weary thoughts inspired by the old cynic’s portrait and bust are
+        quickly dispelled by the original of Verrocchio’s cherub cuddling a
+        dolphin like a baby doll.
+        The Uffizi museum of Italian and European painting
+        stretches in a long U-shape from the Palazzo Vecchio down to the Arno
+        river and back. Duke Cosimo had Vasari design it in 1560 as a series of
+        government offices (hence its name), a mint for the city’s florin, and
+        workshops for the Medici’s craftsmen. Vasari’s greatest architectural
+        work, it is now the home of one of the world’s most famous and
+        important art galleries.
+        Lines requiring achingly-long waits are commonplace
+        year-round. Tickets can now be reserved in advance (inquire at your
+        hotel or the tourist office). See some or all of the 33 rooms, stop for
+        an occasional peek out the window over the Arno and Ponte Vecchio, and
+        recharge your batteries at the museum’s newly reopened café above the
+        Loggia dei Lanzi. It has lovely views of the piazza.
+        Reorganization makes it hazardous to specify room numbers,
+        but the paintings are generally exhibited chronologically from the 13th
+        to the 18th century. Here are some of the highlights:
+        Giotto breathes a warm humanity into his Madonna Enthroned
+        (1310) that distinguishes it from the more formal pictures of the
+        subject by Cimabue and Duccio in the same room. See also Giotto’s
+        Madonna polyptych. Some 30 years later, the Annunciation triptych of
+        Simone Martini, with Mary shying away from archangel Gabriel, has the
+        characteristic elegance and poetry of his Siena school.
+        Paolo Uccello shows a dream-like, almost surrealist
+        obsession with his (unsolved) problems of perspective and
+        merry-go-round horses in his Battle of San Romano (1456). It contrasts
+        with the cool dignity of Piero della Francesca in his Federigo da
+        Montefeltro and wife Battista (1465), portrayed against their Urbino
+        landscape.
+        Some of the museum’s most visited rooms are to come: In
+        his graceful Allegory of Spring (1478) and the almost too famous but
+        undyingly delightful Birth of Venus, Botticelli achieves an enchanting
+        mixture of sensuality and purity. His Flemish contemporary Hugo van der
+        Goes is more down-to-earth in the realism of his huge triptych
+        Adoration of the Shepherds (1478), which influenced Florentine painters
+        like Ghirlandaio.
+        In the Baptism of Christ (1470) of Verrocchio, you can see
+        the earliest identified work of his most famous pupil, Leonardo da
+        Vinci — the background landscape and the angel on the left, beautiful
+        enough to reduce his companion angel to wide-eyed jealousy. Leonardo’s
+        Annunciation (1472–1477) of a few years later already shows his
+        characteristic gentle tone and feeling for precise detail, and the
+        Adoration of the Magi, even as an underdrawing left unfinished by his
+        departure for Milan (1481), reveals his revolutionary power of
+        psychological observation.
+        The northern European rooms include a splendid Portrait of
+        His Father (1490) by Albrecht Dürer; Adam and Eve (1528) by Lucas
+        Cranach; Richard Southwell by Hans Holbein; and a moving Mater Dolorosa
+        by Joos van Cleve.
+        In the mystic Holy Allegory (1490) of Giovanni Bellini, we
+        can appreciate the typical Venetian serenity even without understanding
+        its symbols.
+        The only Michelangelo in the Uffizi is the Holy Family or
+        Doni Tondo (1504), his only known panel painting (he was far better
+        known for his frescoes and sculpture), decidedly sculptural in quality.
+        Without Michelangelo’s strength and torment or Leonardo’s complexity,
+        the third of Italy’s three Renaissance giants, Raphael, brings his own
+        powers of clarity and restraint to the Madonna of the Goldfinch (1505)
+        and a revealing Self-Portrait made when the artist was only 23.
+        Titian has a superbly sensual Venus of Urbino (1538), less
+        Greek goddess than the prince’s mistress she probably was, and an
+        equally disturbing Flora (1515; more works by Raphael and Titian can be
+        found in the Palazzo Pitti). Some are also upset by the eroticism of
+        Parmigianino in his strange but undeniably graceful Madonna with the
+        Long Neck (1534) — just look at those elongated fingers — a masterpiece
+        of the sophisticated and subsequently decadent Mannerism that followed
+        the High Renaissance.
+        There is an intriguing ambiguity to the half-naked peasant
+        youth posing as a Bacchus for Caravaggio (1589), but nothing
+        complicated about the robust sexiness of the Rubens Bacchanale. And
+        compare Caravaggio’s mastery of chiaroscuro (the play of light and
+        dark) in the service of realism in his violent Abraham and Isaac (1590)
+        with the more contemplative style of Rembrandt in the famous Old Rabbi
+        (1658) and other portraits.
+        Designed in the late 13th century by Arnolfo di Cambio
+        (architect of the Palazzo Vecchio and the Duomo) but with a neo-Gothic
+        façade added in 1863, the Franciscan church of Santa Croce (east of the
+        Uffizi) has an important series of Giotto frescoes. The pathos shines
+        through the heavily restored paintings of St. Francis in the Bardi
+        Chapel (c. 1320s), to the right of the apse, and two St. Johns in the
+        Peruzzi Chapel next door. In a chapel in the left transept, the wooden
+        Crucifixion by Donatello (1425) is in affecting naturalistic contrast
+        to the Renaissance idealism of the time.
+        The church is also revered by Florentines as the last
+        resting place of many great Italians. Galileo, Machiavelli, Ghiberti,
+        and composer Rossini are all buried there. Michelangelo’s tomb (right
+        aisle, second bay) was designed by Vasari, with symbolic statues of
+        Painting, Sculpture, and Architecture mourning beneath a bust of the
+        Florentine-born artist who died at 89. Michelangelo wanted the tomb
+        surmounted by the Pietà, now in the cathedral museum (see page 61), but
+        the Florentines almost didn’t get even his body — they had to smuggle
+        it out of Rome. For Florentine-born Dante, they have to be content with
+        a cenotaph, as Ravenna, his burial place, refuses to part with his
+        remains (he was exiled from Florence for political reasons).
+        At the back of the cloister of Santa Croce’s Franciscan
+        monastery adjoining the church, Brunelleschi’s Pazzi Chapel (Cappella
+        dei Pazzi) is a little gem of Renaissance elegance designed in 1443.
+        Its spaciousness is enhanced by geometric patterns of dark stone
+        against whitewashed walls. Luca della Robbia’s subdued glazed ceramic
+        roundels depict the 12 Apostles and Four Evangelists. The most
+        cherished treasure in the Santa Croce Museum is Cimabue’s 13th-century
+        massive Crucifixion, rescued and painstakingly restored after the
+        town’s catastrophic 1966 flood. It now hangs on an electric cable to be
+        hoisted above harm’s way should another flood ever happen.
+        The ominous 13th-century fortress-like palazzo that houses
+        the Bargello Museum (Via del Proconsolo, 4) was Florence’s first town
+        hall and dreaded prison under the jurisdiction of the Police Chief, or
+        Bargello, before becoming the National Museum of Sculpture. The old
+        armory is now the Michelangelo Hall (Sala Michelangelo) greeting you
+        with a dour bust of the master by Daniele da Volterra. Michelangelo’s
+        works here are numerous, including his early masterpiece The Drunken
+        Bacchus (done when he was just 21), and a Virgin and Child marble
+        roundel (1504). Among the Cellini bronzes is an imposing bust of his
+        master, Duke Cosimo. The General Council Hall (Sala del Consiglio
+        Generale) is dominated by the works of Donatello: his vigorous St.
+        George (1416), intended for the Orsanmichele (see page 81); his
+        important David, naked and restless in bronze (1450); and the stone
+        Marzocco lion, the town’s symbol, from the Palazzo Vecchio. You can
+        also see the two bronze panels submitted for the Baptistery doors
+        competition in 1401 by Brunelleschi, the loser, and Ghiberti, the
+        winner (see page 77). On the second floor is a Verrocchio David (c.
+        1471), for which his 19-year-old pupil Leonardo da Vinci is believed to
+        have been the model.
+        From the Mercato Nuovo to Santa Maria Novella
+        Start out from the center, the heart of medieval Florence,
+        on the street named after the drapers’ guild, the Via Calimala. Just
+        south of the café-ringed Piazza della Repubblica is the covered Mercato
+        Nuovo, a 16th-century loggia once called the Straw Market because of
+        the straw products for which Florence was known. The straw items (bags,
+        placemats) are now made in China, as are many of the other tourist
+        tchotchkes on sale here. The selection of tourist mementos is
+        interesting enough, but pales in comparison to the open-air Mercato San
+        Lorenzo just north of the Duomo near the church of the same name. The
+        17th-century bronze statue of a wild boar known as il Porcellino, on
+        the south side of the small Mercato Nuovo, is every Florentine child’s
+        favorite. They say that if you rub it’s burnished snout, and throw a
+        coin in the fountain, your wish for a return trip to Florence will come
+        true.
+        West on the Via Porta Rossa is the 14th-century Palazzo
+        Davanzati; its stern, fortress-like exterior still provides rings at
+        ground level for tethering horses and on upper stories to hold torches
+        and lanterns for festive occasions. Inside, on the first floor, is a
+        museum of typical Florentine domestic life from the 14th to 16th
+        centuries, with furniture, utensils, and ceramics — the most attractive
+        are in the Sala dei Pappagalli (Parrots’ Hall) with its trompe l’œil
+        tapestries frescoed on the walls. After six years of restoration, fall
+        of 2001 will see the grand reopening.
+        The church of Santa Trinita has a late-16th-century
+        Baroque façade with a Gothic interior. Ghirlandaio, master teacher of
+        Leonardo da Vinci, decorated the Sassetti Chapel (far right of the high
+        altar) with frescoes of St. Francis, and the Adoration of the Shepherds
+        on the altar is considered his masterpiece.
+        Florence’s most elegant shops continue the Via de’
+        Tornabuoni’s centuries-old tradition of aristocratic luxury. On the
+        15th-century Palazzo Strozzi, look out for the intricate wrought-iron
+        lanterns; the massive palazzo, once a private residence, is used for
+        special exhibitions and the biennial antique fair. West of here is the
+        Via della Vigna Nuova, where the spill-over of Tornabuoni’s most
+        exclusive stores continues.
+        The cavernous 13th-century Dominican church of Santa Maria
+        Novella is the finest of Florence’s monastic churches. Leon Battista
+        Alberti added the graceful white-and-green marble façade in 1470. The
+        church is rich in artistic treasures, but its most prized, indeed one
+        of the city’s greatest paintings for its early handling of perspective
+        and depth, is the Masaccio Trinity (from around 1427; left aisle, third
+        bay). Mary and John stand on either side of the crucified Jesus upheld
+        by his Father, while the dove of the Holy Spirit hovers between them,
+        the whole forming an inspiring triangle under the coffered ceiling of a
+        Renaissance chapel.
+        The church also boasts one of Italy’s most delightful
+        fresco cycles. Covering the chancel behind the main altar, the
+        Ghirlandaio frescoes of the lives of the Madonna and St. John kept the
+        master’s entire workshop busy from 1485 to 1490. They were paid for by
+        the prominent Tornabuoni family (his biblical scenes are peopled with
+        portraits of his patrons in the latest fashions of the time).
+        Ghirlandaio’s 13-year-old apprentice — Michelangelo Buonarroti — must
+        have picked up a few tips for his future commission of the Vatican’s
+        Sistine Chapel.
+        The Filippo Strozzi Chapel (right of the altar) is
+        decorated with Filippino Lippi’s frescoes of saints Philip and John,
+        rich in color and anecdotal detail: In the monumental Exorcism of
+        Demons in the Temple of Mars, notice the three bystanders holding their
+        noses at the smell.
+        In the Gondi Chapel (left of the high altar), the
+        Brunelleschi Crucifixion (1410), his only scultpure in wood, brings to
+        the human body a characteristic idealized harmony, compared with
+        Donatello’s more personal piece in the church of Santa Croce (see page
+        87). Of another age, at once austere and serene, is the Giotto
+        Crucifixion (1290) in the Sacristy (left transept).
+        Through a separate entrance left of the church, escape the
+        bustle of the piazza in the Dominicans’ 14th-century cloister (Chiostro
+        Verde), with Paolo Uccello’s frescoes of the Universal Deluge. The
+        Spanish Chapel (Cappellone degli Spagnoli) is covered by huge
+        14th-century frescoes by the little known Andrea da Firenze.
+        North of Santa Maria Novella, spare a glance at the
+        simple, clean-lined architecture of the Stazione Centrale (main railway
+        station), built in 1935 during Mussolini’s heyday but somehow defying
+        the prevailing monumental bombast of the Fascist regime that you can
+        see in the monstrosity of Milan’s central station.
+        Heading back down towards the river, have a restful drink
+        in the plush neo-Renaissance bar of the five-star Excelsior Hotel
+        (Piazza Ognissanti) — especially if you’re not staying there. Then
+        cross the square to the church of the Ognissanti (All Saints Church),
+        13th-century but with a Baroque façade of 1637. In Ghirlandaio’s
+        Madonna of Mercy (right aisle, 2nd bay), portrayed immediately to the
+        right of Mary is the Florentine banker-navigator-cartographer Amerigo
+        Vespucci, who gave his name to the continent of America (and whose
+        family was a sponsor of this church). Botticelli is buried in a chapel
+        (right transept), his St. Augustine adorning the church, while in the
+        refectory in the adjoining cloister, you’ll find Ghirlandaio’s Last
+        Supper.
+        South of the Arno
+        There’s nothing very romantic about the murky waters of
+        the Arno river, with its broad, 19th-century lungarni embankments that
+        protect it from flooding. Of the many bridges that cross it, two are
+        noteworthy.
+        The Ponte Santa Trinita, destroyed in 1944, has been
+        rebuilt with the original 16th-century masonry scooped from the bottom
+        of the river, including statues of the Four Seasons. Bartolomeo
+        Ammanati’s three lovely elliptical arches follow drawings by
+        Michelangelo.
+        The Ponte Vecchio, intact since 1345, was Florence’s
+        first, and for centuries only, bridge. The boutiques with their back
+        rooms overhanging the river were built from the 16th to 19th centuries.
+        Across the tops of these small former workshops, Vasari provided a
+        covered corridor for Duke Cosimo to keep out of the rain when crossing
+        from his Pitti Palace to the Uffizi. The duke didn’t like the smell of
+        the bridge’s original butcher shops and had them replaced by goldsmiths
+        and jewelers, whose descendants offer you their high-quality wares
+        today: This is some of Italy’s finest window shopping. A bronze bust
+        (1900) of Italy’s most celebrated goldsmith, Benvenuto Cellini, holds a
+        position of honor in the middle of the bridge with a vantage point of
+        lovely views.
+        In Renaissance times, the quarter south of the Arno,
+        Florence’s “Left Bank,” was an aristocratic preserve where the Medici
+        held court. Today, their palace is a museum, the gardens that hosted
+        their private festivities are a public park and the side streets where
+        workshops supplied them with hand-made marvels are still vibrant with
+        the humming bottegas of today’s artisans.
+        Cross the Ponte Vecchio to the sprawling Pitti Palace
+        (Palazzo Pitti), its dauntingly heavy and graceless façade belying the
+        ornate and colorful interior. After a brief stint living in the Palazzo
+        Vecchio in the Piazza della Signoria, Duke Cosimo I and his wife,
+        Eleonora of Toledo, acquired the palace from the bankrupt Pitti
+        merchant family in 1549 as the Medici’s official residence; it was
+        enlarged and embellished substantially over the centuries.
+        Its seven museums and galleries (following varying and
+        erratic schedules with the exception of the largest and most reliable,
+        the Pitti Gallery) take you into the rich world of the Medici, much as
+        they left it. The important Pitti Gallery (Galleria Palatina) is the
+        family art collection. The paintings are displayed just as the dukes
+        themselves hung them, two-, three-, and four-high, by personal
+        preference rather than in historical sequence. The 26 richly-decorated
+        salons (just a fraction of the Medici residence) are named after the
+        themes of their 17th-century frescoes — Venus, Hercules, Prometheus,
+        etc. As in any collection of family pictures, there’s a preponderance
+        of portraits, though here the aunts and uncles tend to be princesses,
+        cardinals, and popes. It is the most important collection of paintings
+        in Florence after the Uffizi.
+        And the Medici’s taste and means did permit a considerable
+        number of masterpieces. Titian displays his masterly use of color and
+        light in The Concert (Hall 5, Venus), a haunting portrait of The
+        Englishman and bare-breasted Magdalen (Hall 6, Apollo).
+        An early proponent of “make love, not war,” Rubens shows
+        Venus restraining Mars in his vivid Consequences of War and portrays
+        himself on the far left of his Four Philosophers (Hall 7, Mars).
+        Raphael is well represented by a stately Veiled Woman
+        (Hall 8, Jupiter), a classic Madonna of the Chair and Maddalena Doni
+        (Hall 9, Saturn), deliberately imitating the pose of Leonardo da
+        Vinci’s Mona Lisa, and Pregnant Women (Hall 10, Iliad).
+        Caravaggio contributes a typically disturbing canvas, an
+        ugly Sleeping Cupid with intimations of death (Hall 32, Education of
+        Jupiter).
+        Up on the next floor, the Modern Art Gallery (Galleria
+        d’Arte Moderna) is devoted to 19th- and 20th-century Italian art. Most
+        interesting are the Macchiaioli (from the verb “macchiare,” to blotch
+        or stain) school of Tuscan pre-Impressionists, who met at Florence’s
+        Caffè Michelangelo in the 1860s seeking a new freedom from academic art
+        that paralleled the political liberation of the Risorgimento. Giorgio
+        de Chirico and Eduardo de Pisis are among the more important
+        20th-century painters exhibited. In 1999, an additional 100 paintings
+        were added to the collection.
+        The Pitti’s next-most visited gallery, the Silverware
+        Museum (Museo degli Argenti), occupies 16 sumptuously decorated rooms
+        to offset the Medici family’s invaluable treasures — gold, silver,
+        jewels, beautiful 16th- and 17th-century amber and ivory, crystal,
+        porcelain, and Baroque furniture. The Carriage Museum (Museo delle
+        Carrozze), in a wing on the far right of the palace, and the Royal
+        Apartments (Appartamenti Monumentali), upstairs, right of the main
+        entrance, show an opulent, truly palatial life that the palazzo’s dour
+        exterior never lets you suspect. The restoration of the Costume Museum
+        (Museo del Costume), an unusual collection of traditional dress from
+        the 18th–20th centuries, is complete in 2001.
+        Time for a rest in the shade of the cypresses, pines, and
+        holm oaks of the palace’s Boboli Gardens, a favorite picnic destination
+        in Florence. To the modern eye, they form a Renaissance and Baroque
+        theme park dotted with loggias, cool fountains, grottoes with
+        artificial stalactites, and myriad statues of gods, nymphs, and
+        grotesques (derived from the word “grotto”).
+        Directly behind the palace, the Amphitheatre, shaped like
+        a Roman circus and with lovely views of the Palazzo Pitti and the city
+        beyond, was the scene of the Medici’s most extravagant fêtes and staged
+        performances. In the middle of the nearby Pond of Neptune (Vasca del
+        Nettuno), the burly sea god wields his trident in petrified parody of
+        one of the Boboli’s gardeners.
+        After the Pitti’s riches, the unadorned white façade of
+        the nearby Augustinian church of Santo Spirito (Piazza Santo Spirito)
+        is a sobering antidote. Brunelleschi’s design was never completed but
+        the interior preserves the spatial clarity of his Corinthian-capitaled
+        colonnades. In the right transept is a strikingly theatrical Madonna
+        Enthroned by Filippino Lippi.
+        The church of Santa Maria del Carmine is an essential stop
+        on any artistic pilgrimage to Florence. The church itself is an
+        unprepossessing reconstruction after a devastating fire of 1771, but
+        the Brancacci Chapel with the great Masaccio frescoes miraculously
+        survived intact. The bright light of the early years of the
+        Renaissance, the talented painter died at 27 after only five years of
+        promising creative activity (1423–1428), working with his mild-mannered
+        teacher Masolino on scenes from Genesis and the life of St. Peter.
+        Compare Masolino’s sweet and harmonious Adam and Eve in his Original
+        Sin (chapel entrance, upper right) with Masaccio’s agonizing figures in
+        the Expulsion from the Garden of Eden, opposite, to appreciate one of
+        the early Renaissance’s most dramatic statements. Nothing like them had
+        ever been painted before. Florence’s greatest artists, Michelangelo at
+        their head, came to gaze and marvel, sketching Masaccio’s trail-blazing
+        use of light and visual depth as instruments of emotional impact,
+        particularly striking in the broad sweep of his St. Peter Paying the
+        Tribute Money. The chapel frescoes were completed in the 1480s by
+        Filippino Lippi, who painted the side walls’ lower panels.
+        For a last panoramic sunset view of the city dominated by
+        the terracotta cupola of the Duomo, take a bus or taxi to the vast
+        Piazzale Michelangelo (anchored by a second copy of his David). While
+        there, visit the charming Romanesque church of San Miniato (up the hill
+        behind the square); rebuilt in the 11th century, it is Florence’s
+        oldest and one of its most beloved churches. Try to be there in late
+        afternoon when a handful of resident monks chant timeless Gregorian
+        vespers.
+        Tuscany (Toscana)
+        The original territory of the ancient civilization of the
+        Etruscans has always been independent-minded, even aloof, in its
+        attitude to Rome and the other regions. For the serious Italophile, its
+        beauty and riches deserve weeks, months, even years of attention, but
+        no first visit would be complete without at least a brief foray here.
+        After an easy side-trip from Florence to Fiesole, our itineraries go
+        farther afield — west to Pisa and Lucca before turning south through
+        the hills of Chianti to Siena.
+        Fiesole
+        Just 8 km (5 miles) northeast of Florence, 30 minutes on
+        the number 7 bus from the Duomo or Piazza San Marco, the road winds up
+        a wooded cypress-studded hillside, revealing at each bend ever-changing
+        views of Fiesole’s gardens and historical villas and the monuments of
+        the great Renaissance city below.
+        Car drivers can negotiate the winding old side-road Via
+        Vecchia Fiesolana for glimpses of handsome villas half-hidden among the
+        cypresses and olive trees. The town center, Piazza Mino da Fiesole,
+        with its austere cathedral founded in 1028, is the starting-point for
+        some exhilarating hill walks (the tourist office in the main piazza has
+        walking maps), the most immediate being the steep paved lane leading
+        from the square up to the small San Francesco convent and post-card
+        views of Florence.
+        Only some wall fragments remain of the former Etruscan
+        stronghold in Fiesole itself, but there are extensive Roman ruins,
+        including a well-preserved amphitheater dating to 100 b.c.   — still in
+        use for summertime festivals — which seats 2,500 spectators.
+        Pisa
+        In its heyday from the 11th to the 13th centuries, Pisa
+        created a powerful maritime empire down the Tyrrhenian coast and in
+        Corsica, Sardinia, Sicily, Syria, Palestine, and Egypt. Its riches and
+        prestige called for a legacy, providing the funds for the gleaming
+        white marble complex of religious edifices known as the Campo dei
+        Miracoli (Field of Miracles), of which its leaning bell tower is a
+        national icon, left unscathed by the invasions and wars of succeeding
+        centuries. Most rushed visitors see the square, stand in awe of the
+        tilting tower, and leave town.
+        Conquering a flat landscape with serene, other-worldly
+        harmony, this assembly of buildings in an emerald green square also
+        known as the Piazza del Duomo celebrates the whole cycle of life, from
+        baptistery, cathedral, and campanile (a.k.a. the Leaning Tower) to the
+        monumental cemetery of the Campo Santo. The Duomo was built during
+        Pisa’s Golden Age, begun in 1063, to honor Pisa’s victory over the
+        Saracens in Sicily. With Oriental and Byzantine decorative elements
+        reflecting the Pisan Republic’s overseas interests, its four-tiered
+        arcaded façade over three porches is a masterpiece of grace and
+        delicacy. Architect Buscheto didn’t hesitate to write in Latin (in the
+        far left arch) “This marble church has no equal. ” Inside, there was no
+        reason either for local Giovanni Pisano to show false modesty about his
+        superbly sculpted 14th-century marble pulpit (left aisle), arguably the
+        cathedral’s masterpiece.
+        Thanks to its unstable subsoil, the Leaning Tower
+        (Campanile) is out of alignment by about 4.5 m (15 ft) though
+        measurements vary. Give or take a micromillimeter or two depending on
+        annual subsidence, that means the 8-storied belfry stands approximately
+        57 m (187 ft) high on its north side, less on the south. Begun after
+        the Duomo in 1173, it began to lean when only three of its eight
+        stories had been completed (the Duomo is also marginally off-kilter).
+        It has been closed indefinitely to the public since 1990 but is
+        beautiful to view from afar none the less. Scientists are forever
+        seeking new solutions for propping it up, but at its present rate of
+        slippage, you still have at least another 200 years to see it standing
+        more or less upright.
+        The lovely circular Baptistery (Battistero) is topped by a
+        traditional statue of John the Baptist. Inside, left of the baptismal
+        font and altar, is Pisa’s greatest work of sculpture, a hexagonal
+        marble pulpit by Nicola Pisano, father of the Giovanni who designed the
+        cathedral pulpit. The 1260 carving of biblical themes has clear links
+        to French Gothic sculpture, while drawing on models from Roman and
+        Etruscan sarcophagi — a Herculean Daniel and a Mary inspired by heads
+        of Juno and Phaedra.
+        In the 13th-century cloistered cemetery of the Camposanto
+        (Holy Ground — believed to be filled with sacred dirt brought back from
+        the Holy Land during the Crusades), note the Gothic tabernacle
+        enclosing a Madonna and Saints. Within the cloister, in the north
+        gallery, is a striking fresco of the Triumph of Death (1360) showing
+        how a humble person and an aristocrat face the same destiny.
+        Lucca
+        The “sights” of this town take scarcely a day, but the
+        seductive tranquillity within its perfectly-preserved ramparts is
+        irresistible. Things were not always so peaceful here. In the stormy
+        15th and 16th centuries, Lucca’s prosperous silk merchants preserved
+        the peace by intercepting enemy armies and paying them to bypass the
+        town. It has been particularly rich in musicians, most notably
+        Boccherini and Puccini, and hosts a series of music festivals
+        throughout the summer.
+        Begin with a stroll or bicycle ride on the tree-shaded
+        pathway atop the brick 16th–17th century ramparts, along the
+        Passeggiata delle Mura, for a good overall view of the town’s
+        traffic-free centro storico contained within the walls.
+        Begun in 1060, the Duomo San Martino, has a Pisan-style
+        three-storied façade with a Descent from the Cross carved by Nicola
+        Pisano over the north door. Its prized possessions are two: the
+        haunting Volto Santo (Holy Face), a wooden crucifix said to have been
+        carved by Nicodemus and possessing miraculous powers; and the graceful
+        white marble tomb of Ilaria del Carretto Guinigi by master Sienese
+        sculptor Jacopo de lla Quercia (1408) in the former sacristy.
+        Northwest of the cathedral, you’ll find an even more
+        beautiful adaptation of the Pisan Romanesque style of architecture in
+        the town’s other beloved church, San Michele in Foro, less encumbered
+        on its site of the ancient Roman Forum. Begun in 1143, its arcaded
+        façade varies the patterns of its four tiers of columns — sculpted,
+        striped, scrolled, chevroned — in pink, green, black, or white marble.
+        With binoculars, you can spot up on the third tier of arches (third
+        from the right), the heads of Risorgimento heroes Gari­baldi and
+        Cavour. A huge winged statue of the archangel Michael crowns its
+        façade.
+        To capture something of the town’s medieval character,
+        explore the Via Guinigi, with its handsome 14th-century pa­laces, and
+        the towered houses of Via Fillungo, leading to the Roman amphitheater,
+        now the Piazza del Mercato. Nearby, the façade of the church, also of
+        the typical Pisan Romanesque style, of San Frediano has a 13th-century
+        mosaic of the Acsension of Christ. In the interior (fourth chapel on
+        left aisle), look for Jacopo della Quercia’s marble altar (1422).
+        Chianti
+        The best introduction to the Tuscan hill country is a tour
+        of the famous vineyards that grace its southern-oriented slopes. The
+        grapes that qualify as Chianti Classico, distinguished by a coveted
+        black rooster label, grow in the region between Florence and Siena,
+        most of them along the ancient Via Chiantigiana, which is route S222.
+        The liveliest, most colorful time is during the autumn grape harvest,
+        la vendemmia, but tasting — and buying — goes on at many of the Chianti
+        vineyards all year round.
+        Start out at San Casciano in Val di Pesa, 17 km (11 miles)
+        south of Florence, with a bonus for art-lovers of a Simone Martini
+        Crucifixion and other Sienese works in the church of La Misericordia.
+        Southeast across to route S222, you find the characteristic landscape
+        of vineyards interspersed with equally renowned olive groves as you
+        approach Greve, a characteristic town that is the major wine center for
+        the area. (Americans pay homage at a monument in the local piazza to
+        local son Giovanni da Verrazzano, navigator-explorer of New York Bay. )
+        The wine route continues through Castellina with its 15th-century
+        castle and ancient town gate. Then on to Radda, where you should peep
+        in at the Piccolo Museo del Chianti, and to Gaiole in Chianti, one of
+        the best centers for tasting and a place to linger.
+        San Gimignano
+        The haunting silhouette of this “Medieval Manhattan,” a
+        skyline bristling with truncated towers dating to the 12th and 13th
+        centuries, and its lovingly preserved historic center make it the most
+        magical of Tuscany’s hill towns. (One of the most photogenic views is
+        from the north, on the road from Certaldo, home and last resting place
+        of Boccaccio. ) There were once more than 70 towers — erected as
+        symbols of its merchants’ power and prestige — until the town’s
+        Florentine conquerors ordered them dismantled in the 14th century. Just
+        over a dozen remain.
+        The most important are clustered around three adjoining
+        squares: the triangular Piazza della Cisterna named after the city’s
+        13th-century travertine well, surrounded by elegant palaces; the Piazza
+        del Duomo, grouping church and town hall as the center of civic and
+        religious power; and the Piazza delle Erbe ­market place with twin
+        Salvucci towers.
+        The 13th-century town hall, Palazzo del Popolo, houses the
+        civic museums. The small Pinacoteca includes an emotionally intense
+        Crucifixion by Coppo di Marcovaldo and a Taddeo di Bartolo painting of
+        St. Gimignano, in which you can see what the towers of the medieval
+        city looked like. Visit the interior of the 12th-century Romanesque
+        Collegiata (not officially a cathedral but proudly called the town’s
+        Duomo none the less) for its dramatic frescoes of New Testament scenes
+        along the right aisle. In sharp contrast, the Ghirlandaio frescoes in
+        its tiny Santa Fina Chapel (at the end of the right aisle) are a series
+        of sophisticated social portraits (1475) dedicated to the young patron
+        saint of San Gimignano. Against the east wall, flanking the church
+        entrance, are wooden statues of Mary and the Archangel Gabriel by
+        Jacopo della Quercia.
+        For a fine view of the surrounding countryside, Tuscany at
+        its most poetic, climb up to the ruins of the Rocca citadel, the
+        highest point in town and a good picnic spot.
+        Volterra
+        This fortified town perched high on its hill works a sober
+        charm among the buff-stone 13th-century edifices of its Piazza dei
+        Priori and adjacent Piazza San Giovanni. The Palazzo dei Priori (1208)
+        is the oldest of Tuscany’s typical town halls, with a two-tiered tower,
+        battlements, and mullioned windows. It stands opposite the massive
+        triple-arched Palazzo Pretorio, medieval police headquarters. The two
+        squares are separated by the 12th-century cathedral and 13th-century
+        octagonal baptistery. The latter’s baptismal font has bas-reliefs by
+        Andrea Sansovino.
+        Away from the center, you can trace the town’s ancient
+        beginnings in the Etruscan Guarnacci Museum (Via Don Minzoni, 15). The
+        collection includes sculpted stone, alabaster, and terracotta funeral
+        urns dating back to the sixth century b.c. One gaunt statue, Ombra
+        della Sera (Evening Shadow), is an uncanny 2,000-year-old precursor of
+        a modern Giacometti. Volterra has always been known for its local
+        alabaster production as a glimpse in any shop window will confirm.
+        Siena
+        A time-locked city of rich russet browns and weathered
+        ochres, Siena is as perfectly medieval as greystone Florence is a
+        Renaissance showcase, yet contrasts with its centuries-old rival to the
+        north are striking and inevitable. Whereas the nucleus of Florence was
+        built to a strict Roman city plan of straight streets intersecting at
+        right angles, Siena has all the Tuscan hill-town’s haphazard organic
+        forms, straggling up and down a forked ridge of not one but three
+        hilltops. Closed to traffic (and free of taxis), it is not for the weak
+        of knee.
+        While Florentine art developed its formidable intellectual
+        and emotional power, the tone of Sienese painting — Simone Martini, the
+        Lorenzettis, even the Mannerist Sodoma — remained gentle and delicate,
+        bathed in the light and color of its surrounding countryside. But as
+        its obstinately independent spirit has shown, even after the Florentine
+        conquest of 1555 — a spirit epitomized by its lusty Palio
+        tournament — the town is not without vigor. Like an open-air museum,
+        Siena is still a very dignified lived-in town, with fashionable
+        restaurants and boutiques, a vibrant local pride nurtured by economic
+        stability and a rich historic legacy.
+        At its heart is the grand sloping fan-shaped Piazza del
+        Campo, site of the old Roman forum and arena of the town’s world-famous
+        annual Palio horse race. The unique piazza’s red-brick herringbone
+        paving/pavement is divided by nine marble strips for the nine patrician
+        clans that ruled the city at the end of the 13th century.
+        The painterly impact of the “burnt sienna” glows from the
+        arcaded Gothic Palazzo Pubblico opposite, with its splendid 102-m-
+        (335-ft-) high Torre del Mangia (climb to its first tier at 88 m [288
+        ft] for a magnificent view of the city and countryside beyond). The
+        loggia at the tower’s base is a chapel (Cappella di Piazza) marking the
+        city’s deliverance from the plague of 1348.
+        The Palazzo Pubblico’s ground floor houses the offices of
+        the town hall, but its upstairs chambers, frescoed by the city’s
+        foremost artists, have been transformed into a Museo Civico (municipal
+        museum). The Sala del Mappamondo (named after a lost map of the Sienese
+        world painted by Ambrogio Lorenzetti to trace the city’s international
+        banking interests) has two great frescoes by the Siena-born master
+        Simone Martini. To the left is the stately Maestà (Madonna Enthroned;
+        1315) and to the right, Guidoriccio da Fogliano (1328, but whose
+        authenticity has recently been disputed), depicting the Sienese
+        captain’s ride to a historic victory at Montemassi — in the nicely
+        detailed Tuscan landscape, notice the little Chianti vineyard in the
+        military encampment. In the Sala della Pace (Hall of Peace, council
+        chamber of the Nine Patricians), the full force of Siena’s civic pride
+        strikes home in the impressive allegorical frescoes (1337–1339) by
+        another local master, Ambrogio Lorenzetti. One wall is devoted to Bad
+        Government, a gloomy portrait of Tyranny, badly damaged, and the other
+        two to Siena’s own enlightened Good Government, full of fascinating
+        detail of town life — roof-builders, shoe shop, school, outdoor tavern,
+        ladies dancing in the street — and hunters riding out to the
+        surrounding countryside. A second floor loggia is adorned with Jacopo
+        della Quercia’s 15th-century carvings for the city fountain Fonte Gaia
+        (of which a poor 19th-century replica stands in the piazza).
+        Southwest of the Campo, the Duomo, built from the 12th to
+        the 14th centuries, is for many the greatest of Italy’s, possibly all
+        of Europe’s, Gothic cathedrals. The exterior’s majestic black- and
+        white-striped marble banding surrounding Giovanni Pisano’s three
+        intricately carved portals presents that quintessential Italian
+        preference for pictorial qualities over mere architecture. The interior
+        continues the bands of black and white marble, while elaborately inlaid
+        marble paving  — one of the cathedral’s primary attractions, with large
+        sections regularly covered for protection — covers the floor with 56
+        pictures of biblical and allegorical themes, done over two centuries by
+        some 40 artists. Also of major note is the early-16th-century Cardinal
+        Piccolomini Library, off the left aisle. Vividly decorated by
+        Pinturicchio’s action-packed frescoes of the life of Pope Pius II (the
+        locally-born Piccolomini cardinal himself became pope, Pius III, but
+        lasted only ten days). In the left transept is a magnificent octagonal
+        13th-century pulpit carved by Nicola Pisano, with help from son
+        Giovanni and Arnolfo di Cambio. Among its fantastic detail of the new
+        testament scenes, notice the damned being eaten alive in the Last
+        Judgment. The 17th-century Baroque Madonna del Voto Chapel (in the
+        right transept) was designed by Bernini, whose statues of St. Jerome
+        and Mary Magdalen flank the entrance.
+        In the neighboring Cathedral Museum (Museo dell’Opera
+        Metropolitana), Giovanni Pisano’s original sculptures for the Duomo’s
+        façade have strangely distorted poses because they were meant to be
+        seen from below. The museum’s focal point is the Enthroned Madonna
+        (1308) by local wonder boy Duccio di Buoninsegna. Simone Martini’s
+        Miracles of St. Agostino Novello, and Pietro Lorenzetti’s Birth of Mary
+        are not to be missed.
+        The importance of Siena’s 13th- and 14th-century school of
+        art is best illustrated in the imposing Palazzo Buonsignori’s National
+        Art Gallery (Pinacoteca Nazionale). Besides the works of the
+        14th-century masters Duccio, Pietro, and Ambrogio Lorenzetti, as well
+        as Simone Martini, see Siena’s 16th-century Mannerists, painting at a
+        time when the Renaissance teetered on the brink of effete decadence:
+        Beccafumi’s dreamy Birth of Mary and a highly decorative Christ at the
+        Column by Sodoma.
+        Montepulciano
+        South of Siena is a little trammeled niche of Tuscany and
+        some of the region’s most attractive hill towns with excellent local
+        wines. Montepulciano (famous for its superb Vino Nobile di
+        Montepulciano), perched some 610 m (2,000 ft) above sea level, is known
+        as “the Pearl of the 16th Century. ” A stroll along the Via di
+        Gracciano and Via Ricci to see the town’s noble Renaissance palazzi
+        will explain why.
+        The Piazza Grande, the highest point in town, is the site
+        of the graceful town well decorated with griffins and lions. The
+        13th-century Gothic Palazzo Comunale (Town Hall) is a particularly
+        imposing expression of civic dignity. In the austere 16th–17th century
+        cathedral, see Taddeo di Bartolo’s fine triptych on the high altar.
+        Antonio da Sangallo the Elder, architect of many of the town’s palazzi,
+        built his masterpiece, the 16th-century church of San Biagio, southwest
+        of town, a gem of High Renaissance architecture hidden at the end of a
+        cypress-lined road with views of the Chiana valley. The nearby towns of
+        Montalcino (known for its Brunello wines) and Pienza (the first example
+        of Renaissance urban planning) promise small-town distractions and
+        culinary pleasures.
+        Monte Argentario
+        If you’re taking the coast road to or from Rome during
+        warm-weather months, stop off at the fashionable seaside resorts on
+        this pine-forested peninsula beside the town of Orbetello. The sandy
+        beaches and yachting harbors of Port’Ercole and Porto Santo Stefano are
+        favorite weekend destinations for well-heeled Romans (with a growing
+        international presence), but they’re much quieter during the week. Take
+        a boat excursion out to the pretty island of Giglio; it is one of the
+        islands of the Tuscan archipelago that includes Elba, best known as the
+        island of Napoleon’s retreat.
+        Umbria
+        The region has a less glamorous reputation than Tuscany
+        (and is reasonably less crowded), but it’s highly appreciated both for
+        its great artistic treasures and the dreamy rolling green landscapes
+        that inspired them.
+        The area was dominated in the past by the papacy, which
+        conquered the Lombard dukes of Spoleto in the Middle Ages, Perugia in
+        the 16th century, and held sway until the unification of Italy. Apart
+        from pilgrims streaming to St. Francis’s Assisi and university students
+        heading for Perugia, it has remained — at least in the eyes of foreign
+        visitors — a very happy backwater.
+        On 26 September 1997, two major earthquakes rocked the
+        Umbria region, leaving ten people dead and causing extensive damages to
+        local villages. Thousands of people were left homeless, and countless
+        churches and public buildings were forced to close as aftershocks
+        continued through the early days of October. Although the international
+        media focused on the damage caused in Assisi, much of the region
+        suffered structural damage, and many frescoes and monuments important
+        throughout the region were severely damaged or destroyed. Tell-tale
+        signs of scaffolding are still visible, although the most visited
+        destinations got the most immediate attention in an attempt to ready
+        them for the Jubilee Year’s tourism.
+        Orvieto
+        Half the pleasure of this lovely town dramatically perched
+        on a rocky precipice is a first glimpse of it from afar (not so very
+        different today from Turner’s 1828 painting in London’s Tate Gallery).
+        For a good view, approach it from the southwest, on route S71 from Lake
+        Bolsena, or look across from the medieval abbey La Badia (now a hotel),
+        immediately south of town.
+        Gourmands come for its noted white wine, art-lovers for
+        the magnificent Gothic cathedral. Scores of architects worked on the
+        church from the 13th to the 17th centuries (its central bronze doors
+        were added in 1964), but its glory remains the gleaming façade (its
+        mosaics were a 17th-century addition), with its four slender spired
+        pilasters and its rose-window above the beautifully scrolled porches.
+        At the base of the two northern pilasters, look closely at Lorenzo
+        Maitani’s marvelous carved marble bas-reliefs of scenes from the Old
+        Testament and the Last Judgment.
+        Grey and white bands of marble give the interior a
+        spacious simplicity. Off the right transept, the recently restored San
+        Brizio Chapel (a.k.a. Cappella Nuova) is famous for the 1447 frescoes
+        covering the ceiling by Fra Angelico — Christ in Glory — and by Luca
+        Signorelli (around 1500) on the walls. To the left, Signorelli portrays
+        himself and Fra Angelico as bystanders in the vivid Preaching of the
+        Antichrist (identified here with Savonarola). The nude figures in the
+        Resurrection of the Dead on the right wall are considered by some art
+        historians as less convincing. Many echo Leonardo da Vinci’s comparison
+        to “sacks of nuts. ”
+        The Cathedral Museum in the Palazzo Soliano includes other
+        works by Signorelli, a Simone Martini polyptych, and sculpture by Nino,
+        Andrea, and Giovanni Pisano.
+        If you want to cool off, explore the monumental Pozzo di
+        San Patrizio, a 16th-century well dug 63 m (206 ft) down into the
+        volcanic rock on the nort heast edge of the precipice. Well lit by 72
+        windows, two spiral staircases of 248 steps take you right down to the
+        water level. The town sits atop a labyrinth of tunnels, caves, and
+        storerooms carved into the soft tufa, begun by the Etruscans and
+        elaborated upon by the ancient Romans. Guided tours explain the
+        earliest chapters of this ancient town with a visit to its subterranean
+        depths.
+        Spoleto
+        Its greatest tourist attractions are the summer music and
+        arts festivals (in particular the world-famous Spoleto Festival
+        established in 1957), but the town’s beautiful natural setting amid
+        densely wooded hills also makes it a base for hikes into the
+        countryside. Especially popular is the oak forest (and monastery) on
+        Monteluco, favored by St. Francis and St. Bernardino of Siena.
+        An important Roman outpost with an excavated amphitheater
+        as proof, Spoleto also boasts a sober Romanesque cathedral with
+        17th-century additions, decorated with damaged but still graceful Fra
+        Filippo Lippi frescoes (1469). The tomb for the licentious painter-monk
+        who seduced Sister Lucrezia (the model for many of his Madonnas) was
+        designed by Filippino Lippi, the son of Filippo and Lucrezia.
+        Assisi
+        The enduring popular appeal of St. Francis (1182–1226) has
+        turned his native pink-hued town into Italy’s major pilgrimage
+        destination, second only to Rome. Its basilica, like the peaceful
+        medieval town center, has been beautifully preserved, and the
+        centuries-old pilgrim trade manages (sometimes just barely) to avoid
+        the unashamed commercialism that blights other religious shrines.
+        The basilica of San Francesco is in fact two churches, one
+        above the other, built on top of the saint’s simple tomb in the crypt.
+        Unfortunately, the basilica was the region’s one structure that
+        suffered the most damage during the earthquakes of 1997, whose
+        epicenter was located just outside of Assisi. Several priceless
+        frescoes were severely damaged or destroyed, notably invaluable works
+        by Cimabue (1226–1337) featured on a portion of the Upper Church’s
+        vaulted ceiling, which plunged to the floor during the quakes.
+        The Lower Basilica was begun in 1228, two years after
+        Francis’ death and the year of his canonization, and the frescoes were
+        painted in the 14th century, but a Renaissance porch now precedes the
+        Gothic side entrance. The subdued and mystical light of the low vaulted
+        nave evokes the sober piety of the Franciscan tradition. Tuscan painter
+        Simone Martini has decorated the St. Martin Chapel (first left) with
+        exquisite frescoes, including a most aristocratic Jesus appearing in
+        St. Martin’s dream. Stairs in the nave lead down to the crypt and St.
+        Francis’s tomb, rediscovered only in 1818, centuries after it had been
+        concealed from Perugian plunderers. The simplicity of the tomb would
+        have been much more preferred by il Poverello than the well-intentioned
+        lavishness showered upon the basilica.
+        The superb frescoes of the life of Jesus in the St. Mary
+        Magdalen Chapel (closest to altar on the right nave) and of St.
+        Francis’s vows of poverty, chastity, and obedience above the elegant
+        Gothic high altar are attributed to Giotto (1307) and his workshop.
+        In the right transept, the Cimabue’s famous portrait of
+        St. Francis, believed to be a close physical resemblance, shows him to
+        the right of the enthroned Madonna. Over in the left transept, see
+        Pietro Lorenzetti’s noble Descent from the Cross.
+        In the Upper Basilica, reopened in 2000 after intense
+        round-the-clock restoration, Cimabue’s works in the apse and left
+        transept have turned black, looking like photo negatives because of the
+        oxidized white lead in his paints, yet you can still feel the intensity
+        of the crowd’s anguish in his Crucifixion, blessedly untouched by the
+        earthquake’s damaging force.
+        In the brilliantly illuminated nave, the faithful are
+        exalted by one of the most grandiose series of frescoes in Christendom
+        and, sadly, some of the most damaged in the earthquake. The basilica’s
+        highlight, and generally accepted as the work of a young Giotto, the
+        Life of Francis (1296-1304) is movingly celebrated in 28 scenes along
+        the lower tier (starting from the right transept), while 32 frescoes in
+        the upper tier illustrate scenes from the Old and New Testament.
+        Detractors question that Giotto designed the entire series but usually
+        agree that numbers 2 to 11 are his work.
+        Penetrate the historic heart of Assisi along the Via San
+        Francesco, with its 15th-century Pilgrims’ Hostel (Oratorio dei
+        Pellegrini) at number 11. Its frescoes are attributed to Perugino. The
+        noble Piazza del Comune is the town center, grouping medieval palazzi
+        around the old Roman forum. A triumph of Christianity over paganism,
+        the Corinthian-columned church of Santa Maria sopra Minerva was built
+        on the site of a Roman temple under Augustus. A small Pinacoteca art
+        museum is across the square.
+        The austere little church of San Damiano dates to the 11th
+        century. It’s a lovely 3 km- (2 mile-) stroll down from the Porta
+        Nuova, and is a point of pilgrimage for those curious to see the wooden
+        crucifix that spoke to a troubled 27-year-old Francis in 1209, telling
+        him to go and repair the world.
+        Perugia
+        Dominating the Umbrian countryside from its 494-m
+        (1,600-ft) hill, Perugia is emphatically more secular and more profane
+        than its mystical Umbrian neighbor Assisi. But the imposing weight of
+        its past is lightened by the lively cosmopolitan studentry of its two
+        universities (its state university, one of Italy’s largest, was founded
+        in 1270; its international division was set up by Mussolini) and its
+        contemporary popularity as the sight of one of Europe’s most important
+        jazz festivals each July. Perugia’s antiquity is symbolized on the
+        north side of town by the lovingly preserved Arco Etrusco
+        (Etruscan — and partly Roman —  triumphal arch) that was incorporated
+        into its medieval ramparts.
+        In its picture-perfect town center, something of its old
+        aggressive civic power is evoked in the formidable Palazzo dei Priori
+        (town hall) looming over the Piazza 4 Novembre at the far side of its
+        pedestrian-only Corso Vanucci. Nicola Pisano’s intricately carved and
+        recently restored 13th-century Fontana Maggiore (Great Fountain) has
+        long been everyone’s favorite point of rendezvous, in the shadow of the
+        14th-century cathedral. Together with the Palazzo dei Priori, the
+        cathedral sustained some damage from Umbria’s 1997 earthquake.
+        The fourth floor of the town hall (entrance on Corso
+        Vannucci) is given over to the Galleria Nazionale dell’Umbria, expanded
+        in 1999, a handsomely modernized setting for a splendid collection of
+        Umbrian and Tuscan paintings from the 13th to 18th centuries. It
+        includes a Fra Angelico Triptych and Piero della Francesca’s
+        Annunciation and Madonna with Angels. But Umbria’s pride and joy is the
+        work of Perugia-born Pietro Vanucci, a.k.a. Perugino (1445–1523). Look
+        out for his Adoration of the Magi and a Madonna della Consolazione as
+        sweet and serene as the Umbrian landscape of which you’ll catch a
+        glimpse through the museum windows. Pinturicchio, master of narrative
+        fresco and a student of Perugino, is represented by his Miracles of the
+        Saints.
+        Next door on the busy pedestrian street of Corso Vannucci
+        is the Collegio del Cambio, 15th-century hall and chapel of the
+        bankers’ guild. The vestibule is decorated with handsome 17th-century
+        Baroque walnut panelling. But it is the Audience Hall (Sala
+        dell’Udienza) that is its highlight, covered with a delightful series
+        of Perugino frescoes (1496–1500), considered his masterpiece. The left
+        wall is allegorical, devoted to the bankers’ widely acknowledged
+        virtues, Prudence, Justice, Fortitude, and Temperance, while religious
+        themes invoke their piety on the other walls. (Fortitude and one of the
+        Sibyls are attributed to Perugino’s 17-year-old pupil, Raphael. )
+        The presence of the Perugina chocolate industry (creator
+        of the Perugino bacio in 1922) is surprisingly low profile. There is no
+        flagship shop or outlet per say, though some of the larger cafés in
+        town carry a representation of the confections produced by the local
+        factory which, although open to the public, would be of interest only
+        to serious chocolate buffs.
+        Gubbio
+        Some 40 km (25 miles) north of Perugia, this no-nonsense
+        stalwart hill town is not easy to get to, and once you’re there it
+        remains hard to navigate — if you don’t like climbing steep cobbled
+        streets. But for anyone who cherishes the tranquility of a
+        quasi-unspoiled medieval atmosphere, Gubbio is a delight. The
+        brick-paved Piazza della Signoria is the center stage of “the city of
+        stone. ” Its 14th-century crenellated Palazzo dei Consoli is one of the
+        grandest civic edifices in all Italy, and from the piazza and the
+        palazzo’s belltower you have a magnificent panorama of the town and
+        surrounding country. Then climb (even higher! ) to the cathedral and
+        the Renaissance courtyard of the 15th-century Palazzo Ducale. In
+        warm-weather months an open funivia brings you up to the basilica of
+        Sant’Ubaldo, the town’s patron saint, and you can go from there by foot
+        to the 12th-century military fortress La Rocca for unmatched views of
+        the wild Appennine Mountains.
+        THE NORTHEAST
+        Throughout Italy’s history, its northeast regions have
+        linked the country to the exotic outside world of Byzantium and the
+        Orient through Venice and its Repubblica Serena, and to the Alpine
+        countries north of the Dolomites, while the plains of Emilia-Romagna
+        from Ravenna to Parma provided an anchor to the heartland of the Po
+        valley.
+        The result is a rich variety of distinctive cities and
+        colorful hinterland. The afterglow of Venice’s once-powerful empire is
+        undimmed. Made possible by its conquests, elegant Palladian villas
+        grace the Veneto mainland from Venice to Padua and Vicenza. The glories
+        of Verona extend from its grand Roman arena to the palaces of the
+        medieval and Renaissance families whose intrigues and love stories
+        inspired Shakespeare. In Emilia-Romagna, the pride and creativity of
+        the great city-states is still very much in evidence in the monuments
+        and museums of Bologna, Ferrara, and Parma. Stretch your muscles in the
+        Dolomites, with its first-class winter sports and summer hiking, or
+        soak up sun and sea in the Adriatic resorts around Rimini.
+        Venice (Venezia)
+        These palazzos, canals, and lagoons claim a place apart in
+        our collective imagination. In this new millennium, Venice remains a
+        dreamworld more than ever, its myth more powerful than its harsh
+        reality. Even when it threatens to disintegrate into nightmare at times
+        of winter floods, Carnival shenanigans, or summer hordes, visitors can
+        take refuge in a café once frequented by Casanova or in a quiet back
+        alleyway away from the congestion, and continue their dream
+        uninterrupted. One of the city’s many blessings is that there remain so
+        many quiet and beautiful corners that have changed little with time.
+        Another obvious bonus, although impossible to over-emphasize, is the
+        absence of cars, the simple joy of wandering around a town relieved of
+        traffic and pollution, of standing on a little humpback pedestrian
+        bridge far from the Grand Canal and hearing only the water lapping
+        against the moss-covered walls, or the occasional swish of a sleek
+        gondola that appears out of nowhere. Staying forever is most likely to
+        cross your mind.
+        Go in May or October, if you can — the crowds at Easter
+        and from June to September can be horrible (May and October are hardly
+        better, but are at least a bit cooler). Venice at Christmas has become
+        fashionable and the late-winter Carnival (generally falling in February
+        or March), very commercial. In the winter months it is dank and cold
+        but with a mystical beauty all its own. But whenever you go, don’t try
+        to do it all in a day. Without the time to meander and explore those
+        hidden corners, you risk not seeing much more than Piazza San Marco,
+        and understanding very little of the city’s inherent charm. Give
+        yourself a bare minimum of three days, time to get lost (you’re never
+        very far from the main landmarks signposted with bright yellow arrows).
+        The town has more than enough sights to see, but you can taste much of
+        its pleasures before you even set foot inside the museums, churches,
+        and monuments. The only “must” is Venice itself.
+        Grand Canal (Canal Grande)
+        From the railway station or the parking lot of Piazzale
+        Roma, you begin with a vaporetto waterbus along the Canal Grande, the
+        most uniquely stunning main street in the world. Use this wonderful
+        first contact with the city as your introductory (and inexpensive)
+        tour.
+        Vaporetto number 1 takes you to the historic center of
+        town, Piazza San Marco. Accelerated lines miss out on many of the
+        canal’s sites; airport motor launches cross directly to San Marco from
+        the Lido so drop your bags off at the hotel and then hop on the number
+        1 in the opposite direction, round-trip. Save your gondola ride — yes,
+        it’s touristy and expensive but not to be missed — for when you’re
+        settled in.
+        Along the Grand Canal’s 3.8 km (more than 2 miles),
+        varying in width from 30 to 70 m (100 to 230 ft), are the old trading
+        headquarters and warehouses of its distant commercial heyday. Known
+        locally as ca’ (short for casa) as well as palazzo, the marble, brick,
+        and white limestone palaces range over 600 years from
+        Venetian-Byzantine to Renaissance, Baroque, and Neoclassical, but most
+        of them are exotically 14th- and 15th-­century Gothic, Venice’s
+        “trademark” in architectural styles. Their sea-resistant limestone
+        foundations stand on massive pinewood stilts driven 8 m (26 ft) into
+        the lagoon bed.
+        Lining the Grand Canal
+        The superb Renaissance Palazzo Vendramin-Calergi, where
+        Richard Wagner died in 1883, is today the winter casino. The gilt has
+        gone from the freshly restored façade of the 15th-century Ca’ d’Oro
+        (Golden House), but it’s still the town’s most beautiful and best
+        preserved of the city’s Gothic palaces and home to the Galleria Giorgio
+        Franchetti Museum. Italy’s most impressive post office, Fondaco dei
+        Tedeschi was once the trading-center of Czechs, Hungarians, and
+        Austrians as well as the Germans of its name. Just beyond, the
+        shop-lined white marble Rialto Bridge arches the canal at its narrowest
+        point. The 18th-century Palazzo Grassi has been recently restored by
+        Gae Aulenti for major art exhibitions of world-class quality. The
+        prefecture puts its bureaucrats in the fine Renaissance Palazzo Corner
+        (or Ca’ Grande), while gondoliers claim Othello’s Desdemona lived in
+        the lovely late-Gothic Palazzo Contarini-Fasan.
+        The 700-year-old Fondaco dei Turchi was a warehouse for
+        the merchants of Constantinople, now the Natural History Museum. It
+        stands next to the plain brick 15th-century Megio wheat granary,
+        decorated only by battlements and the republic’s seal of St. Mark’s
+        lion. The imposing 17th-century Baroque Ca’ Pesaro houses the Modern
+        Art Museum. Come back early in the morning to the covered 20th-century,
+        neo-Gothic Pescheria (fish market) and its adjoining produce market.
+        The university has a department in the handsome 15th-century Gothic Ca’
+        Foscari. The Ca’ Rezzonico is itself a fine specimen of the
+        18th-century Venetian art for which it is now a museum. Beyond the
+        wooden Accademia Bridge and the Accademia art museum, the perspective
+        is completed by the magnificent Baroque church of Santa Maria della
+        Salute that has always marked the arrival at (or departure from) Piazza
+        San Marco just across the way.
+        Around Piazza San Marco
+        Building-space on the water being what it is, Venice has
+        only one real piazza (all others are called “campi”), but in
+        comparison, any other contender would have died of shame anyway.
+        Gloriously open to sky and sea, Piazza San Marco — to locals, just “the
+        Piazza”—embodies the whole Venetian motherlode of history and
+        adventure. Its airy arcades reach out to the 900-year-old basilica and
+        turn a corner past the soaring brick campanile to the Piazzetta and
+        landing stage of St. Mark’s basin (il Bacino), historic gateway to the
+        Adriatic and distant ports beyond. For centuries, the odysseys of
+        victorious commanders and commercial ventures of local merchants began
+        and ended here.
+        This is where th e thousand-year-old Repubblica Serena
+        fell in 1797, at the hands of Napoleon. While he was busy removing the
+        four ancient bronze horses from the basilica’s façade (since returned)
+        along with other art treasures to ship back to Paris, he was said to
+        remark that the Piazza San Marco was “the world’s most beautiful salon.
+        ” He closed off the Piazza’s west end with an Ala Napoleonica
+        (Napoleonic Wing), through which you now enter the Museo Correr,
+        devoted to paintings and documents of Venetian history.
+        The north and south arms of the square, the 16th-century
+        Procuratie Vecchie and Procuratie Nuove, were the residences of the
+        republic’s most senior officials. They are now lined with Murano glass
+        and souvenir boutiques, exclusive jewelry and lace shops, and, most
+        important for weary or hungry travelers, elegant 18th-century cafés.
+        During the Austrian occupation, the enemy frequented Quadri on the
+        north side, while Italian patriots met only at Florian, opposite. In
+        warm weather months, their spirited 4-piece orchestras play everything
+        from “Moon River” to polkas and Neapolitan love songs. Pigeons chase
+        seed-vendors chasing tourists chasing their children chasing pigeons.
+        To catch the piazza and the basilica bathed in moonlight and
+        quasi-deserted is a magical thing.
+        The glittering façade of the Basilica di San Marco forms
+        an exotic backdrop, illuminating Venice’s unique role at the crossroads
+        of Eastern and Western culture. What began in a.d. 830 as the Doges’
+        chapel for the remains of the evangelist Mark, the republic’s patron
+        saint, was rebuilt in the 11th century as a grandiose
+        Byzantine-Oriental basilica influenced by the Hagia Sofia in
+        Constantinople. Greek mosaicists were brought in to decorate the arches
+        and domes. Five Romanesque portals correspond to the five Islamic-style
+        domes covering the church’s Greek-cross ground plan. With its five
+        mosquelike domes, it is the most sumptuously exotic and orientally
+        inspired church ever built in the Roman Catholic world.
+        The first portal on the left is the only one decorated
+        with an original 13th-century mosaic, depicting the Transfer of St.
+        Mark’s Body, smuggled out of Alexandria, Egypt. The mosaic also shows
+        the basilica with the famous bronze horses brought from Constantinople
+        after the Crusade of 1204 (the ones over the triple-arched main
+        entrance are copies, the originals are kept in the basilica museum
+        since their recent restoration).
+        There is a soft glow in the gilded interior from the
+        mosaics, gently illuminated by high stained-glass windows, more
+        evocative yet with the worn patina of the elaborate inlaid-marble
+        flooring. Entire books have been written about the original mosaics on
+        the five domes and the great barrel vaults separating them, dating from
+        the 11th to the 15th centuries. Among the best are the 12th-century
+        Pentecost dome in the nave and the central dome’s 13th-century
+        Ascension. Others have been heavily restored or replaced, not with true
+        mosaics, but with reproductions in colored stone of drawings by such
+        artists as Bellini, Mantegna, and Tintoretto. The whole is worthy of
+        its nickname, “church of gold. ”
+        The imposing high altar stands over St. Mark’s tomb.
+        Behind it is the basilica’s greatest treasure, the Pala d’Oro (Golden
+        Altarpiece), dating back 1,000 years and bejeweled in its present form
+        in the 14th century. Guides will tell you that its 255 enameled panels
+        were encrusted by master Venetian and Byzantine artisans with close to
+        2,000 precious stones, including pearls, garnets, sapphires, emeralds
+        and rubies. It requires an entrance fee, as does the Tesoro (Treasury),
+        a collection of the Crusaders’ plunder. To the left of the high altar
+        is a small chapel whose 10th-century Madonna di Nicopeia, a bejeweled
+        icon also from Constantinople, is said to have healing powers and is a
+        runner-up as Venice’s protective patron after St. Mark.
+        Steep stairs to the right of the main entrance lead to the
+        small Museo Marciano, where you can see the original four tethered
+        bronze horses, dating from the 2nd or 3rd century a.d. and a privileged
+        close-up of the basilica’s mosaic ceilings from the museum’s open
+        galleries. From the outdoor Loggia dei Cavalli, you get an excellent
+        view over the Piazza San Marco and its principal monuments.
+        To the right of the loggia (north of the basilica), is the
+        restored Torre dell’Orologio (Clock Tower), reopened in 2000 in time
+        for its 500th anniversary. The clock mechanism, all gilt and polychrome
+        enamel, still keeps perfect time, activating statues of two green
+        bronze Moors that hammer out the hour. For centuries, the clock tower
+        has been every Venetians favorite rendezvous point, an arched
+        ground-level entranceway leading to the Merceria, a narrow zig-zagging
+        boutique-lined street that cuts through this ancient quarter on its way
+        north to the Rialto Bridge.
+        The piazza’s beloved Campanile (Bell Tower), at 99 m (324
+        ft) is the highest structure in the city, for 10 centuries its belfry,
+        lighthouse, weather vane, and gun turret. Emperor Frederick III rode
+        his horse up its spiral ramp (tourists can opt for the elevator).
+        Criminals were suspended from it in wooden cages. In 1902, it cracked,
+        crumbled and collapsed unexpectedly. Ten years later, on its 1,000th
+        anniversary, it was rebuilt using much of the original brick and
+        rescuing one of its five historic bells that is still used today:
+        “com’era, dov’era” (“as it was, where it was”). Its collapse
+        fortunately hurt no one, but did crush Jacopo Sansovino’s beautiful
+        16th-century Loggetta, equally lovingly restored as the entrance to the
+        campanile’s elevator. On clear days, enjoy a view high over the
+        Adriatic and all the way north to the pink-tinged Dolomites.
+        The two tall columns facing out over St. Mark’s Basin were
+        brought from Constantinople in the 12th century. They are topped by
+        statues of St. Mark’s winged lion and the city’s first patron saint,
+        Theodore (replaced by St. Mark), with his dragon.
+        On the waterfront sits the Doges’ Palace (Palazzo Ducale),
+        for 900 years the focus of Venice’s uncontested power and pomp, evoked
+        in the imposing elegance of its delicate pink marble and white
+        limestone façades with their airy arcades and loggias. Erected over an
+        older Byzantine-style castle, the present 14th- to 15th-century
+        Flamboyant Gothic building fronts the Piazzetta and the basin, the
+        first building to behold upon arrival in Venice. It is open to the
+        public with audio guides (in various languages) available at the
+        entrance.
+        Where the palazzo joins the basilica’s southernmost flank
+        is the Porta della Carta (Gate of the Paper, where the doge posted his
+        decrees and scribes gathered). The Gothic sculpture shows the doge
+        kneeling before St. Mark’s lion, flanked by Prudence above Temperance
+        in niches on the left, and Fortitude above Charity on the right. (The
+        book in the lion’s paw that you see all over Venice is inscribed: Pax
+        tibi, Marce evangelista meus, “Peace unto you, my evangelist Mark. ”
+        )
+        In the inner courtyard the Scala dei Giganti staircase is
+        so named for Sansovino’s giant statues of Neptune and Mars. Visitors
+        take the golden Scala d’Oro past the Doge’s opulent private apartments
+        to the spectacularly decorated council chambers on the third floor.
+        Here, as in most of the city’s palaces and churches, the walls are
+        decorated with painted panels and canvases by Venetian masters rather
+        than delicate frescoes, too easily damaged by the Venetian climate.
+        Look out for Veronese’s Rape of Europa and Tintoretto’s
+        Bacchus and Ariadne and Vulcan’s Forge in the Anticollegio; a masterly
+        allegorical series by Veronese glorifying Venice in the Sala del
+        Collegio, where foreign ambassadors were received; and weapons and
+        suits of armor in the Armory (Sala d’Armi).
+        Highlight of the palace tour, back down on the second
+        floor, is the huge Sala del Maggior Consiglio (Great Council Hall),
+        where ordinary citizens presented their complaints in person in the
+        Republic’s most democratic days before the oligarchy reserved it for
+        their secret deliberations. The last doge presented his abdication to
+        Napoleon here. Of the 76 doges portrayed here, one is blackened out,
+        Marino Faliero, beheaded for treason in 1355. Tintoretto’s Paradise
+        adorns the entrance wall above the doge’s throne. Said to be the
+        world’s largest oil painting, 22 by 7 m (72 by 23 ft), it was done,
+        with the help of son Domenico, when the artist was 70. Look for the
+        brilliant colors of Veronese’s oval ceiling painting of Venice Crowned
+        by Victory, forerunner of the Baroque tours de force in
+        perspective.
+        For those hoping to go from the sublime to the sinister,
+        the palace prisons, neat and tidy today along their narrow corridor,
+        become all too romantic with their 17th-century Baroque Bridge of Sighs
+        (Ponte dei Sospiri). The celebrated passage to doom, linking the Ducal
+        palace with the prisons, supposedly moved its users to sigh on their
+        way to the torture chambers (now off-limits). Some of the original
+        graffiti can still be seen in the prisons, one of which held Casanova
+        for 15 months in 1755 before he escaped.
+        The waterfront Riva degli Schiavoni (Quay of the Slavs)
+        begins at the Ducal Palace, named after the Dalmatian merchants who
+        unloaded their goods here. The ghosts of Dickens, Wagner, and Proust
+        wander around the lobby of the venerable Danieli Hotel, a former doge’s
+        residence that is one of Italy’s most romantic (the romantic lobby bar
+        offers a moment of rest for the weary).
+        Probably nowhere is there so much spectacular painting on
+        view in such a tiny space as in the Scuola di San Giorgio degli
+        Schiavoni. This captivating building was the confraternity guildhall of
+        the wealthy schiavoni merchants who commissioned Vittore Carpaccio
+        (whose parents belonged to the community) to decorate their hall. His
+        nine pictures, completed between 1502 and 1508, cover the walls of the
+        ground-floor chapel. Note the wonderfully ornate wooden ceiling. It is
+        one of a number of scuole (literally, “schools” or confraternities)
+        unique to the days of the Venetian Republic.
+        Just four minutes by vaporetto from the Piazzetta, on its
+        own little island, is the church of San Giorgio Maggiore; its campanile
+        offers the most photogenic view of the city and its lagoon. The
+        16th-century church is a rare ecclesiastical building by Andrea
+        Palladio, the master Renaissance architect from nearby Vicenza whose
+        classic designs have so dominated aristocratic residential architecture
+        throughout Europe and North America. His customary Corinthian-columned
+        elegance prevails here, extended from the façade to an airy interior.
+        Two superb paintings by an elderly Tintoretto flank the main altar,
+        Gathering of the Manna and an otherworldly Last Supper, in which Jesus
+        administers communion while servants bustle to clear up the dishes. The
+        resident monks still offer mass sung in Gregorian chant every
+        Sunday.
+        Around the Accademia
+        With an inherent pride so justifiably timeless, the
+        rambling Galleria dell’Accademia (Accademia Gallery) is devoted almost
+        exclusively to the artistic legacy of the master artists of Venice and
+        the Veneto, from the 14th century of the republic’s emerging glory to
+        the 18th century of its gentle decadence. One of Italy’s most important
+        art museums, it offers the chance to see just how little Venice has
+        changed over the centuries. Here are only some of its most
+        representative highlights:
+        Room 1: The 14th-century Coronation of the Madonna of
+        Paolo Veneziano, first of the city’s great masters, glowing with
+        characteristic Venetian color and texture.
+        Room 2: Giovanni Bellini, youngest and most gifted member
+        of the painter family, brings gentle humanity to his Enthroned Madonna
+        with Job and St. Sebastian (1485).
+        Room 4: Andrea Mantegna (a brother-in-law of the Bellini
+        family) shows why St. George, the dragon-killer, became the most
+        appropriate patron saint for England.
+        Room 5: Giorgione’s Tempest (1505) is one of the museum’s
+        most cherished, most mysterious treasures, a girl calmly nursing her
+        child in a landscape prickling with the electricity of the approaching
+        storm.
+        Room 7: Lorenzo Lotto, troubled loner among Venice’s
+        16th-century artists, portrays a Gentleman in his Study with subtle,
+        somber psychology.
+        Room 10: This is the most important of Renaissance rooms.
+        Titian’s Pietà, a vibrant last work completed by pupil Palma il
+        Giovane, was originally intended for his tomb in the Frari church (see
+        page 131); Veronese’s Feast in the House of Levi was meant to be the
+        Last Supper, until the Holy Inquisition complained about its “buffoons,
+        drunkards, dwarfs, Germans, and similar vulgarities”; Tintoretto gives
+        full play to his dark sense of drama in the Miracle of St. Mark.
+        Room 17: Canaletto’s hugely popular 18th-century vedute
+        (views) of Venice were aristocratic precursors of modern postcards; in
+        such works as Island of San Giorgio Maggiore, Francesco Guardi achieved
+        both poetry and melancholy.
+        Room 20: Gentile Bellini breathes little life into the
+        grand pageant of his Procession on San Marco (1496), but it remains one
+        of the museum’s most fascinating “photographs” of Renaissance
+        Venice.
+        Room 21: Vittore Carpaccio depicts in nine canvases the
+        bizarre Story of St. Ursula, a British princess, said to have led
+        11,000 virgins on a pilgrimage to Rome, all of whom were raped and
+        slaughtered on their way back.
+        To the east of the Accademia along the Grand Canal, a
+        breath of the 20th century awaits you at the Peggy Guggenheim
+        Collection of modern art in the Palazzo Venier dei Leoni. Home of the
+        American heiress until her death in 1979, this unfinished 18th-century
+        palace provides a delightful canal-side setting for what is widely
+        considered one of the world’s most comprehensive collections of modern
+        art. Works include those by Picasso, Marcel Duchamp, Magritte,
+        Kandinsky, and Klee, but it is known above all for Jackson Pollock,
+        Mark Rothko, and Robert Motherwell. In the garden are sculptures by
+        Giacometti, Henry Moore, and the collector’s husband, Max Ernst.
+        Guggenheim and her dogs are buried here. A lovely limited-menu café
+        behind the garden and a new gift shop were added in 2000.
+        Where the Grand Canal empties into the lagoon stands the
+        imposing church of Santa Maria della Salute — “la Salute” to the
+        Venetians — is the masterpiece of Baldassare Longhena, built to mark
+        the city’s deliverance from a plague in 1630. For a Baroque edifice
+        (and one of the finest outside of Rome), the interior is rather sober,
+        even chaste. One of Tintoretto’s best, the Marriage at Cana, is on the
+        wall opposite the entrance, while three of Titian’s most vivid canvases
+        decorate the chancel: Cain and Abel, Abraham Sacrificing Isaac, and
+        David and Goliath, their drama heightened by the perspective di sotto
+        in su (looking up from below).
+        To the west of the Accademia, the Ca’ Rezzonico is another
+        canal-side design of Longhena, completed in the 18th century and now a
+        museum (reopened in 2000) dedicated to those swan-song years of the
+        Venice’s Most Serene Republic, la Serenissima. When the last of the
+        wealthy Rezzonico family disappeared, Elizabeth Barrett and Robert
+        Browning bought the palazzo, and the poet died in a first-floor
+        apartment in 1889. The extravagant ballroom and soaring allegorical
+        frescoes like Giambattista Tiepolo’s Merit between Virtue and Nobility
+        in the “Throne Room” (actually for Rezzonico weddings) and others, more
+        wistful, by Guardi all catch the tone of a declining Venice and the
+        frivolous lives of the idle rich.
+        Venice was home to a number of scuole that were not
+        “schools” at all but old confraternities similar, minus their religious
+        affiliation, to today’s Freemasons, Rotarians, Elks, or Lions. North of
+        Ca’ Rezzonico, the Scuola Grande di San Rocco is Venice’s richest
+        confraternity, in a fine 16th-century chapter house next to its own
+        church. Local master artist Tintoretto (1518–1594) won a competition to
+        create for the hall some 50 paintings (the largest collection of his
+        work anywhere) over a period of 23 years, a series comparable in
+        grandeur to Giotto’s frescoes in Padua’s Scrovegni Chapel or Florence’s
+        Brancacci chapel by Masaccio. In the Sala Grande, see the high drama of
+        Moses Striking Wate r from the Rock and a fascinating Temptation of
+        Christ, with Satan portrayed as a beautiful youth. Tiepolo and Titian
+        are interlopers here, the latter with a solitary albeit remarkable
+        easel painting of the Annunciation. Tintoretto’s masterpiece in
+        chiaroscuro effects is the grandiose Crucifixion in the Sala
+        dell’Albergo. You’ll find a self-portrait just right of the room’s
+        entrance.
+        Nearby is the immense brick and white-marble Gothic Church
+        of the Frari (full name Santa Maria Gloriosa dei Frari, built by the
+        Franciscans), above all celebrated for the high altar adorned with
+        Titian’s jubilant Assumption of the Virgin. The master’s only painting
+        on such a massive scale is a triumph of primary reds, blues, and
+        yellows that irresistibly draw you up to the altar. Drag yourself away
+        to see his other work here, the Madonna di Ca’ Pesaro (left nave), in
+        which St. Peter presents the Mary to the Pesaro, a wealthy local
+        family. Venetian composer Monteverdi’s tomb is in a chapel left of the
+        altar.   Don’t miss Titian’s own monumental tomb (in the right aisle);
+        he died in 1576 during a local plague. Donatello has sculpted a fine
+        polychrome wood St. John the Baptist for his compatriots’ Florentine
+        Chapel, to the right of the altar.
+        Back on the Grand Canal again: Longhena’s exuberant
+        Baroque Ca’ Pesaro is now the town’s Modern Art Gallery, devoted
+        principally to a small but impressive collection of purchases from the
+        Venice Biennale exhibitions. Italian artists — Futurists Giovanni
+        Fattori and Telemaco Signorini and the Ferrara trio of Filippo de
+        Pisis, Carlo Carrà, and Giorgio de Chirico — are better represented
+        than other Europeans, of whom Matisse, Klee, and Ernst are the most
+        notable.
+        Around the Rialto
+        The ancient commercial heart of the city, named after the
+        ninth-century settlement on Rivo Alto (high bank), the Rialto bridge is
+        one of three that crosses the Grand Canal. Here, the Oriental spices,
+        and silks and exotic cargoes from faraway ports were unloaded from the
+        republic’s ancient galleons. The merchants headed for the banks, the
+        sailors to the brothels. Today, the action is in the food markets and
+        boutiques on the Grand Canal’s west bank. The Pescheria (fish market)
+        bustles early in the morning except Sunday and Monday, while the
+        Erberia (fruit and vegetables) is open until late afternoon for those
+        looking for picnic supplies. Hidden amongst it is the little
+        11th-century church of San Giacomo di Rialto — San Giacometto to
+        them — claimed by locals to be the town’s oldest.
+        The 16th-century Rialto Bridge is one of Venice’s
+        architectural icons, designed by ­Antonio da Ponte for a competition
+        entered by Michelangelo, Palladio, and Sansovino — it’s still one of
+        the liveliest spots in town. Northeast of the bridge, past the Fondaco
+        dei Tedeschi post office, seek out the little 15th-century church of
+        Santa Maria dei Miracoli. Its refined façade of delicate inlaid colored
+        marble and intricately carved friezes has won it the name of “golden
+        jewel box” (scrigno d’oro), its local designer Pietro Lombardo more
+        sculptor than architect. A laborious 10-year restoration brought its
+        gem-like beauty to light in 1999.
+        It’s worth carefully mapping out your visit to the Campo
+        Santi Giovanni e Paolo. Follow the Calle Larga Giacinto Gallina to the
+        humpbacked Ponte del Cavallo bridge for the all-important first view of
+        the piazza’s magnificent equestrian statue of Bartolomeo Colleoni,
+        considered one of the finest in the world. With his last and greatest
+        piece of sculpture brilliantly evoking all the fierce resolution of a
+        condottiere riding into battle, Andrea Verrocchio need not regret
+        abandoning painting to his pupil Leonardo da Vinci. Colleoni willed his
+        huge fortune to Venice on the understanding that his monument would be
+        on Piazza San Marco. Once dead, he had to settle for this spot in front
+        of the Scuola of San Marco, a clever Venetian solution. The piazza’s
+        main attraction is the massive 13th-century Gothic church of Santi
+        Giovanni e Paolo, a name compressed by Venetians into San Zanipolo.
+        Built by the Dominicans, it was the doges’ funeral church with some 25
+        buried here, many in masterpieces of monumental tombs.
+        Returning to the Grand Canal: You’ll find in the glorious
+        Ca’ d’Oro the quintessential decorative tradition of Venetian
+        architecture, arguably more successful in its compact form here than in
+        the beautiful but sprawling Doges’ Palace. Completed in 1440, its
+        Flamboyant Gothic design has a flair and grace that bewitch you into
+        imagining the long-gone gilt of its façade (from which it earned its
+        name). Take another, more leisurely, boat-ride for the view from the
+        canal. The treasures of the Ca’d’Oro’s Galleria Franchetti of
+        Renaissance art include Andrea Mantegna’s St. Sebastian and Titian’s
+        Venus at the Mirror.
+        Off the Beaten Track
+        Among the corners of town far from the crowd, the old
+        Jewish Ghetto (northeast of the railway station) is particularly
+        peaceful and reveals a fascinating page of Venetian history. It was the
+        former site of an abandoned iron foundry, ghetto in old Venetian
+        dialect, which lent its name to this and scores of other future
+        enclaves for the forced isolation of Jewish (or other minority)
+        communities throughout Europe. In 1516, some 900 Jews (rising to a peak
+        of nearly 5,000 by the mid-17th century) were confined to what was then
+        a remote and isolated island.
+        They built the six- and eight-story tenements you see
+        today, cramped quarters in buildings twice as high as those permitted
+        elsewhere, with some floors no more than 6 ft high. The only way to
+        visit any of the six still active 16th-century synagogues is with a
+        guided tour offered by the Museo Ebraico in the Campo del Ghetto Nuovo.
+        A handful of Jewish families still live in the Ghetto.
+        On the island of the Giudecca, you’ll find another of the
+        great Palladio-designed churches (one of two in Venice), the Redentore.
+        The grace of its overall form is best viewed from across the canal,
+        because, like St. Peter’s in Rome, the dome disappears at closer
+        quarters behind its elongated nave. The Giudecca takes it name either
+        from the Jews (giudei) who lived here prior to the Ghetto’s founding or
+        from the giudicati, nobles banished here by ducal judgment. It’s now a
+        quiet residential refuge popular with artists — and tourists seeking to
+        escape the mobs.
+        Out in the lagoon, Venetians have been manufacturing glass
+        on the island of Murano since 1292, when the hazardous furnaces were
+        moved away from the city center. Today, its factories and shops are an
+        undeniable tourist trap, but the museum (Museo Vetrario) tracing the
+        glass industry back to Roman times is worth a look. Many enjoy watching
+        burly fellows blowing molten globules into cute little green giraffes.
+        The island’s quiet spot is the 12th-century Venetian-Byzantine church
+        of Santa Maria e San Donato, with a powerful mosaic in the apse.
+        The island of Burano is a simple fishing village, true
+        haven of tranquility, though the olden days of ladies making lace on
+        the doorsteps of their brightly colored houses, artists on the quay and
+        no hustlers is all but history. A local attempt to keep alive its
+        centuries-old lace-making legacy continues, though much of what’s
+        hawked is machine-made in China.
+        Hemingway’s favorite old hangout, the romantically
+        overgrown island of Torcello, beyond Burano, is one of the lagoon’s
+        oldest inhabited spots, very prosperous until emptied by a malaria
+        epidemic. The mosquitoes have gone, but its superb cathedral remains.
+        Founded in the seventh century and reconstructed in 1008, it’s probably
+        the finest of the Venetian-Byzantine churches, one of Europe’s finest
+        outside of Ravenna. In the apse there’s a moving mosaic of the Madonna
+        above a frieze of the 12 Apostles. Notice the fine Corinthian capitals
+        on the slender Greek marble columns.
+        With its sandy beaches and smart hotels, the Lido is as
+        restful as any fashionable seaside resort. After a couple of days in
+        Venice, its cars come as something of a shock, though tourists and
+        locals alike still prefer bicycles. Nostalgics take tea in the Grand
+        Hôtel des Bains to recall the decadent 1900s, evoked there by Thomas
+        Mann’s novella (and Luchino Visconti’s movie) Death in Venice. A few
+        public beaches are the principle draw during the summer months when
+        Venice’s weather and heavy humidity can sap the most energetic of
+        tourists.
+        Veneto
+        The Venetian mainland reflects some of the Serenissima’s
+        artistic and architectural glories. Most of the cities remained under
+        its domination until the 15th century, yet retained much of their
+        individuality.
+        An autostrada and easy train service link Venice to Padua,
+        Vicenza, and Verona for those in a hurry, but others should take the
+        charming back roads; this is one of Italy’s principal wine growing
+        regions outside of Tuscany’s Chianti area.
+        The Brenta Canal
+        When Venetian aristocrats gave up the high seas for a more
+        leisurely life on the land, they built Palladian Renaissance villas and
+        extravagantly frescoed Baroque country houses on the banks of the
+        Brenta Canal between Venice and Padua. For those with time, a romantic
+        way to visit some of the best is on the burchiello, a modern version of
+        the rowing barge that took the gentry, Casanova, and Lord Byron to
+        their trysts and parties in the country. Get details from the city
+        tourist office on the eight-hour trip, which goes in either direction
+        on alternate days, optional return by bus, from March–October. It stops
+        at a number of villas en route.
+        Otherwise, follow the canal along the pretty country road
+        (route S 11) to Padua (Padova). First stop, off a side road to Fusina,
+        is Palladio’s La Malcontenta (1571), to which a too-flighty Venetian
+        countess was sent to pine, malcontentedly, in exquisite isolation on
+        the canal. The villa, with its classical portico to catch the summer
+        breezes, was the Renaissance architect’s “visiting card” for scores of
+        commissions, copied worldwide, especially on the cotton plantations of
+        America’s Deep South, where elegant porch-living became an article of
+        faith.
+        At nearby Oriago, the Palladian style can be seen in Villa
+        Gradenigo, and at Mira, in the 18th-century Villa Widmann. The
+        influence is clear even in the most spectacular of the Brenta villas,
+        at Stra, the opulent Villa Pisani, or Villa Nazionale. Built for the
+        Pisani doges in 1756, with 200 rooms, Tiepolo frescoes in the ballroom,
+        and vast park with pond, labyrinth, and stables, it was purchased by
+        Napoleon in 1807 and subsequently hosted Tsars, Hapsburg emperors, and,
+        for their first meeting in 1934, Hitler and Mussolini.
+        Padua (Padova)
+        This proud university town — Galileo taught physics here
+        from 1592 to 1610 — was a major center of the Risorgimento
+        reunification movement. Something of the old spirit remains at the
+        handsome Neo-Classical Caffè Pedrocchi, the activists’ meeting place on
+        a little square off bustling Piazza Cavour. First opened in 1831, it
+        reopened in 2000 after a renovation resuscitated much of its historic
+        character.
+        North along the Corso Garibaldi is Padua’s undisputed
+        draw, the 14th-century Scrovegni Chapel, also known, due to its site
+        among ruins of a Roman amphitheater, as the Arena Chapel. As a penance
+        for his father’s usury, the patrician Enrico Scrovegni built the simple
+        little hall in 1303 specifically for the great Giotto frescoes.
+        Beautifully preserved, these are considered some of the most important
+        artworks of the early Re­nais­sance. In 38 pictures arranged in three
+        rows under a starry heavenly-blue vault, Giotto tells the story of Mary
+        and Jesus. Among the most moving, look for the Kiss of Judas, the
+        Crucifixion, and the Lamentation. A monumental Last Judgment covers the
+        entrance wall.
+        The entrance to the important Piazza del Santo south of
+        the city center is guarded by Donatello’s grand statue of Gattamelata,
+        the 15th-century Venetian condottiere Erasmo da Narni, perfect ideal of
+        a Renaissance hero, whose “honeyed cat” nickname still mystifies
+        historians. Behind him is Padua’s great site of pilgrimage, the 13th-
+        and 14th-century Basilica of Sant’Antonio, the city’s protector simply
+        known as II Santo, built in honor of the Portuguese-born Franciscan
+        monk who died in Padua in 1231. The Romanesque façade makes a striking
+        contrast with the eight Byzantine cupolas and two minaret-like towers
+        around a central Gothic cone-shaped dome, reminiscent of Venice’s
+        Basilica San Marco. In the lofty Gothic interior, Donatello’s seven
+        sculptures at the high altar include a stoical Crucifixion and large
+        bronze reliefs narrating St. Anthony’s miracles. Of prime importance is
+        the saint’s tomb to the left of the altar. The patron saint of lost
+        items, it is covered with photos, flowers, and notes of petition left
+        by the streams of pilgrims who come from all corners of the world. St.
+        Anthony’s feastday is June 13, when the saints’ relics (otherwise kept
+        on display in the basilica’s Cappella del Tesoro) are paraded through
+        town.
+        Vicenza
+        This is the home town of Andrea Palladio (1508–1580), the
+        most important architect of the High Renaissance, a must-see
+        destination for architecture lovers or those interested in history and
+        design. At the center, Piazza dei Signori is graced by Palladio’s first
+        public work, the Basilica Palladina (1549), not a church at all, but
+        the old Roman concept of a gathering place for the lawcourts and
+        assemby hall of the Gothic Palazzo della Ragione that it encases with a
+        colonnade and loggia. If you wonder what to think of it, Palladio’s
+        modest opinion was that it “ranked among the most noble and most
+        beautiful edifices since ancient times, not only for its grandeur and
+        ornaments, but also its materials” (hard white limestone). Inside is a
+        museum of his designs and models.
+        The main commercial street is, inevitably, Corso Andrea
+        Palladio, lined with the master’s elegant mansions (today converted to
+        major banks, swank stores, and cafés) and others by disciples; his
+        simple home was at no. 163. The 15th-century Palazzo da Schio (number
+        147) is also known as Ca’d’Oro, after the famous Venetian Gothic
+        palace. Turn off on Contrà Porti for others. You’ll find Vicenza’s
+        greatest opus (his country villas were another story) where the Corso
+        widens out into the Piazza Matteotti to give him more freedom for the
+        wonderfully airy Palazzo Chiericati. Its Museo Civico houses works by
+        Tintoretto, Veronese, Hans Memling, and Van Dyck.
+        Across the piazza in a little garden, the audacious Teatro
+        Olimpico is Palladio’s last work (completed by his protoge Vincenzo
+        Scamozzi in 1584). Facing an amphitheater auditorium is a fixed décor
+        of classical Roman statuary and columns that looks far deeper than its
+        4 m (14 ft), a permanent stage “curtain” of trompe l’oeil depicting the
+        ancient streets of Thebes. Begun by Palladio the year of his death, it
+        was the first covered theater in Europe and is still used today.
+        Take route N 247 to Monte Berico and Palladio’s most
+        celebrated building, the hilltop Villa Rotonda, considered one of the
+        most perfect buildings ever constructed and Palladio’s finest. Designed
+        as a belvedere for Cardinal Capra in 1567, it’s an exquisite piece of
+        applied geometry, a domed rotunda set in a square surrounded on all
+        four sides by simple Ionic-columned porticoes. It offers different
+        views of town and countryside with the changing light of day. It’s a
+        ten minute walk to the Palladian-inspired Villa Valmarana, notable for
+        the Tiepolo frescoes that grace its interior.
+        Verona
+        Shakespeare’s “Fair Verona” of Romeo and Juliet fame,
+        Verona was first a favorite of ancient Roman emperors and the
+        “barbarian” rulers that followed. The city likes to be known as la
+        Degna, the Dignified, but it also has a very lively and well-to-do
+        atmosphere, stimulated by the presence of its Adige river that flows
+        swiftly down from the Dolomites. The memory of its fierce medieval
+        history lingers still, the tales of family feuds that inspired
+        Shakespeare’s Romeo and Juliet ended only with the 14th-century
+        ascendancy of the tough Scalageri dynasty, in turn conquered by Venice
+        in 1405.
+        The hub of city life is the vast Piazza Brà, with the town
+        hall on its south side and the great Roman A rena dating back to a.d.
+        100. Only four of its outer arches survived an 1183 earthquake
+        undamaged, but the inner arcade of 74 arches is intact. The elliptical
+        amphitheater’s 22,000 seats sell out months in advance for summertime
+        open-air productions of “Aida. ” People in the least expensive top-row
+        seats enjoy a terrific view of the surrounding city and
+        countryside.
+        Along the north side of the Piazza Brà, the Liston, a
+        people-watcher’s delight lined with smart cafés and fine restaurants,
+        is the street for the Veronese bourgeoisie’s popular evening stroll
+        (passeggiata). It leads to the boutiques, galleries, and antique shops
+        of the equally fashionable Via Mazzini.
+        Turn right at the end down Via Cappello for the
+        13th-century palazzo that the local tourist authorities will have you
+        believe was Juliet’s House (Casa di Giulietta Cappelletti), complete
+        with balcony. The graffiti that covers the entranceway and ancient
+        walls is a poignant reminder of how well beloved and internationally
+        embraced this universally renowned storia d’amore is.
+        The Piazza delle Erbe along the ancient elongated Roman
+        forum makes the prettiest of marketplaces. Its medieval houses and old
+        umbrella-covered stalls surround a 14th-century fountain and a line of
+        columns, one of which bears the lion of St. Mark, in former allegiance
+        to Venice. The quasi-adjoining Piazza dei Signori (a.k.a Piazza Dante)
+        is the somber and elegant square ringed by crenellated palazzos and
+        Verona’s important historical Antico Caffé Dante. The 14th-century
+        Arche Scaligeri (Scaligeri Tombs) are found just beyond this, some of
+        the most elaborate Gothic funerary monuments in Italy.
+        West of Piazza Brà, the massive brick 14th-century
+        Castel­vecchio fortress on the Adige river now houses an art museum.
+        Its collections are principally of the Venetian school, notably
+        Mantegna’s Holy Family, a Giovanni Bellini Madonna, and Lorenzo Lotto’s
+        Portrait of a Man, attributed by some to Titian.
+        The austerely handsome 9th–12th-­­centuries basilica of
+        San Zeno Maggiore (dedicated to the city’s patron saint), is Verona’s
+        most visited church. With superb bronze doors and an imposing
+        free-standing brick cam­panile, it is a rare jewel of Italian
+        Romanesque architecture. The 14th-century battlemented tower to the
+        left is the remnant of an old abbey. The dignity to which the town
+        aspires is there in the simple interior, illuminated by the magnificent
+        Mantegna triptych (1459) on the high altar; two of its panels are in
+        London.
+        Dolomites
+        The landscape of Italy’s eastern Alps is a mixture of rich
+        green Alpine meadows with jag­ged white limestone and rose-colored
+        granite peaks. Summer hiking in the largely German-speaking region of
+        Alto Adige (Austrian South Tyrol till 1918) is a delight. Well-marked
+        paths lead to farmhouses and rustic mountain-restaurants where you can
+        try the local bacon (Speck) or spinach dumplings (Spinatknödl) as a
+        change from pasta.
+        Bolzano (Bozen)
+        South Tyrol’s historic capital makes a good base for
+        hikes. It has a 14th-century Gothic church with a characteristically
+        Austrian polychrome tiled roof. Inside is a 16th-century sculpted
+        sandstone pulpit and marble altar. Get your hiking equipment on the old
+        arcaded shopping street, Via dei Portici (Laubengasse). Then head
+        northeast of town to the Renon (Ritten) plateau for views of the
+        Dolomite peaks, reached by cableway and rack railway.
+        Cortina d’Ampezzo
+        The queen of Italian winter-sports resorts has elegant
+        hotels, smart boutiques, and a bouncing nightlife. In a sunny sheltered
+        basin high in the Boite valley of the eastern Dolomites, it provides
+        excellent skiing facilities as well as skating and bobsledding. It is
+        also a favorite with summer hikers. Take the cable car to Tofana di
+        Mezzo for an awesome view clear down to the Venetian lagoon. Equally
+        spectacular are the panoramas from the Belvedere di Pocol and Tondi di
+        Faloria.
+        Emilia-Romagna
+        The two regions were united at the time of the
+        19th-century Risorgimento, with Emilia following the Apennines from
+        Bologna to Piacenza, while Romagna covers the eastern area of Ravenna
+        and the Adriatic resorts around Rimini down to Cattolica.
+        Rimini
+        The Adriatic coast, of which Rimini is the chief resort,
+        has wide sandy beaches, at some points stretching 300 m (1,000 ft) from
+        the water’s edge back to the dunes. Its lively hotels, beach clubs, and
+        myriad discos make Rimini a favorite playground for the sun-seekers
+        (Germans, Scandinavians, and Eastern Europeans arrive in droves) while
+        in off-season months it is considerably more sleepy.
+        Inland, on the other side of the railway, is the old city
+        that was Ariminium to the Romans. The 27 b.c. triumphal arch (Arco
+        d’Augusto), anachronistically ornamented with medieval battlements,
+        stands at the junction of the imperial highways from ancient Rome: Via
+        Flaminia and Via Emilia (which gave the region its name). The Ponte di
+        Tiberio bridge built over the Marecchia river in a.d. 21 is still in
+        use. The unfinished 15th-century Tempio Malatestiano is an important
+        Renaissance design of Leon Battista Alberti, incorporating elements of
+        the Arco d’Augusto in the façade. More pagan temple than church, it
+        served as a mausoleum for the cultivated but cruel tyrant, Sigismondo
+        Malatesta, and his mistress (later wife), Isotta degli Atti.
+        To the south of Rimini are the resorts of Riccione, very
+        popular, and the quieter Cattolica. Cesenatico, to the north, has a
+        colorful fishing port.
+        Ravenna
+        For those who find it difficult to appreciate mosaics as
+        we usually see them, in fading indecipherable fragments, the
+        beautifully preserved mosaic decoration of Ravenna’s churches, up to
+        1,500 years old, come as an exciting revelation. They stand at the
+        summit of the art as originally practiced by the Byzantines, and are
+        said to be the finest in Europe.
+        Now some 10 km (6 miles) from the sea, the ancient capital
+        of the Western Roman Empire was once a flourishing port on the Adriatic
+        facing the Greek world. Honorius, last emperor of Rome, made it his
+        capital in 404, followed by his sister Galla Placidia who ruled as
+        lavishly. Ruled in the early sixth century by Theodoric, king of the
+        Ostrogoths, it was recaptured for Emperor Justinian in 540, and
+        Byzantine culture left its mark for another two centuries.
+        You’ll see something of the town’s Venetian-dominated era
+        on the graceful Piazza del Popolo, bordered by the 17th-century Palazzo
+        Comunale — Venetian insignia on the piazza’s two columns have been
+        replaced by local saints Apollinaris and Vitalis. Next to the church of
+        San Francesco, in a building of 1780, is the tomb of Dante, who died
+        here, in exile, in 1321, with a fellow poet’s epitaph: “Here I lie
+        buried, Dante, exiled from my birthplace, son of Florence, that
+        loveless mother. ”
+        The oldest most striking of the Byzantine monuments, in
+        the northern corner of the city center, is the fifth-century Mausoleum
+        of Galla Placidia. Three sarcophagi stand in the cross-shaped chapel,
+        but no one knows if her remains (she died in 450) are in one of them
+        (her husband and son should fill the others). The deep blue, gold, and
+        crimson mosaics on the vaults and arches depict St. Laurence, the
+        Apostles, and the Good Shepherd Feeding His Sheep (over the
+        entrance).
+        In the same grounds is the magnificent three-story brick
+        basilica of San Vitale, consecrated in 547. Its narthex is set at an
+        angle to the main entrance (through a Renaissance porch). The octagonal
+        construction provides the interior with seven exedrae, or recesses, the
+        eighth being the choir and apse. The Old Testament scenes, such as
+        Abraham Sacrificing Isaac, are more lively than the rigidly formal
+        Emperor Justinian and Empress Theodora, with their court retinue, and
+        Christ between two angels, St. Vitalis, and, far right, Bishop
+        Ecclesius holding a model of the church. The cloisters house a National
+        Museum of Roman, early Christian, and Byzantine Sculpture.
+        You can see the art of mosaics still being practised in
+        workshops along the nearby Via Giuliano Argentario.
+        Next to the present-day 19th-century cathedral, the
+        fourth-century Battistero Neoniano (Baptistery of Bishop Neon) has a
+        fine mosaic procession of the Apostles. It was built as the baptistery
+        for the original cathedral that no longer stands.
+        East of the city center, the early sixth-century church of
+        Sant’­Apollinare Nuovo was built by the Christianized Ostrogoth king
+        Theodoric. In the nave, the church’s famous Byzantine mosaics show, on
+        the left, Ravenna’s fortified port of Classis, from which a procession
+        of 22 virgins follows the three Magi with gifts for Jesus on his
+        mother’s lap; on the right, from Theodoric’s palace, 26 male martyrs
+        march towards Christ.
+        Five km (3 miles) south of the town, protected only by a
+        couple of cypresses from an incongruous wilderness of highways and
+        bleak urban development, stands the lovely church of Sant’Apollinare in
+        Classe (549). Next to it is a splendid cylindrical 11th-century
+        Romanesque campanile. In the apse of the Greek-columned interior is a
+        delightful mosaic of St. Apollinaris, Ravenna’s first martyr and
+        bishop, surrounded by 12 sheep representing the Apostles, with Moses
+        and Elijah in the clouds above him.
+        Bologna
+        The capital of Emilia-Romagna is a thriving town with a
+        certain patrician atmosphere to its beautifully-preserved historic
+        center lined by loggias or arcade-covered sidewalks, 21 miles of them.
+        It is famous as the home of Europe’s oldest university, established in
+        the 10th century on the foundation of a renowned law school dating back
+        even earlier to the 5th century, the end of the Roman empire. Bologna
+        also boasts of the diploma its Philharmonic Academy gave Mozart in
+        1770 — though he might have done quite well without it. The town’s
+        revered age-old place in Italian gastronomy compares to that of Lyon in
+        France.
+        On the west flank of the handsome Piazza Maggiore, the
+        massive medieval Palazzo Comunale with its Renaissance porch is a
+        striking expression of Bologna’s civic power. The 14th-century basilica
+        of San Petronio ranks among the most imposing of Italy’s Gothic
+        churches. It has a fine central portal with reliefs of Old Testament
+        scenes on its pilasters sculpted with great dignity and power by
+        Siena-born master Jacopo della Quercia. Adam’s pose in the Creation
+        scene (top left) inspired the Michelangelo figure reaching out to God
+        on the Sistine Chapel ceiling. The soaring vaults of the sober interior
+        have the monumentality of French or German Gothic.
+        In the adjoining square, the 16th-century Neptune Fountain
+        is one of the town’s most popular symbols, for which Giambologna
+        sculpted the bronze sea god surrounded by nymphs and cherubs.
+        A medieval atmosphere clings to the old houses in the tiny
+        streets behind the Metropolitana cathedral to the north. At the end of
+        the Via Rizzoli, the two leaning towers are all that remain of a whole
+        forest of more than 200 medieval status-symbols — like those of San
+        Gimignano in Tuscany (see page 101). The Torre degli Asinelli, 98 m
+        (320 ft), is the taller, with 498 steps to its rooftop view. Built in
+        1109, it leans more than 2 meters (7 1/2 ft), less than its twin, Torre
+        Giselda, that leans 3 m (10 ft).
+        You’ll find the city’s characteristic arcaded palazzi
+        along the Via Zamboni leading past the university to the Pinacoteca
+        Nazionale. The Pinacoteca’s fine collection is devoted in large part to
+        the Bologna school, most notably the Baroque paintings of Guido Reni,
+        and the Carracci family, of whom Annibale was the most gifted — see his
+        Annunciation and Madonna in Glory. Look out for Raphael’s very
+        important Ecstasy of St. Cecilia, a highlight of the museum, and
+        Parmigianino’s Madonna di Santa Margherita.
+        South of the city center, the founder of the Dominican
+        order is buried in the church of San Domenico, 13th-century but with
+        many 18th-century Baroque modifications. The monk’s marble tomb (Arca
+        di San Domenico, 6th chapel, right aisle) is one of Bologna’s
+        treasures. Although the monk died in Bologna in 1221, the tomb was
+        designed much later by Nicola Pisano with additional works by Nicolò
+        dell’Arca and the 20-year-old Michelangelo. He did the saints Petronius
+        and Proculus, and the angel on the right — the first and last time he
+        ever put wings on an angel.
+        Ferrara
+        A mere half-hour’s drive from Bologna on the autostrada
+        takes you to this stronghold of the high-living d’Este
+        dukes — archetypal scheming, murderous, lovable Renaissance villains
+        who ruled from 1200 to 1600. In their formidable Castello Estense, a
+        14th-century moated fortress that is this lovely town’s centerpiece,
+        guides tell delightfully dubious stories of what went on in the damp
+        dungeons.
+        You get a sense of the dukes’ grandeur among the
+        Renaissance palazzi of the Corso Ercole I d’Este, part of a
+        15th-century urban expansion, Addizione Erculea, that was one of the
+        most ambitious pieces of town planning of its age. The d’Estes’ Palazzo
+        dei Diamanti (9,000 pointed pieces of diamond-shaped marble on its
+        walls) houses the Pinacoteca Nazionale, with notable works of the
+        Ferrara masters Cosmè Tura, Ercole de’ Roberti, Garofalo, and Dosso
+        Dossi.
+        The triple-gabled 12th-century cathedral still has its
+        loggia of shops attached to the south wall. The cathedral museum
+        exhibits two major works by Ferrara’s 15th-century master Cosmè Tura,
+        St. George and the Annunciation, and sculptures by Jacopo della
+        Quercia, Madonna of the Pomegranate and St. Maurelius.
+        Parma
+        The home of two famous painters, Correggio and
+        Parmigianino, and birthplace of the conductor Arturo Toscanini, has
+        much more to offer than just great cheese and ham. The Piazza del Duomo
+        forms a harmonious space for the graceful octagonal baptistery, begun
+        in 1196, and the austere nobility of the 12th-century Romanesque
+        cathedral and its 13th-century campanile. Inside, on the ceiling of the
+        central octagonal dome, are Correggio’s greatest masterpieces, his
+        frescoes of the Assumption of the Virgin (1530) where he achieved, in
+        the truest sense, exalting emotion without the sentimentality of
+        Mannerist imitators.
+        The lovely 13th-century pink Verona marble baptistery has
+        superbly sculpted doors by Benedetto Antelami, who also carved most of
+        the 12 statues of the months in the interior.
+        Behind the cathedral, the 16th-century Renaissance church
+        of San Giovanni Evangelista also has in its dome a fine Correggio
+        fresco of the Vision of St. John on Patmos. Look for the Parmigianino
+        frescoes in the first, second, and fourth chapels on the left aisle. In
+        the 16th-century Renaissance church of Madonna della Steccata (Via
+        Garibaldi), Parmigianino painted the frescoes of the Foolish and Wise
+        Virgins on the arch above the high altar.
+        In the charming Camera di San Paolo (Via Melloni), you’ll
+        find the Benedictine convent’s private dining room for the highly
+        unconventional abbess, Giovanna da Piacenza. She commissioned Correggio
+        to decorate it in 1519 (his first work) with mischievous putti angels
+        and a very pagan view of Chastity as symbolized by the goddess
+        Diana.
+        The Galleria Nazionale (on Piazzale Marconi) exhibits more
+        excellent works of Correggio and Parmigianino, and an added prize of
+        the collection, the sketch of a young girl, Testa di Fanciulla, by
+        Leonardo da Vinci.
+        THE NORTHWEST
+        Lombardy, Piedmont, and the Ligurian coast make up the
+        country’s most prosperous region. Industry and commerce have made the
+        fortune of its three great cities — Milan, Turin, and Genoa. If the
+        latter has drawn on the riches of the seas, Milan and Turin, in close
+        contact with France and Germany just across the Alps, have had the
+        added underpinning of a flourishing agriculture in their Po valley
+        hinterland. The early lords of this constant economic expansion also
+        called on the greatest artists both from Italy and beyond, from
+        Leonardo da Vinci to Jan Van Eyck.
+        The region has won world recognition in the vanguard in
+        the arts, of modern design of clothes and furniture, and of the
+        automobile and communications industries.
+        For relaxation, the Italian Riviera east and west of Genoa
+        alternates a rugged coastli ne with the occasional fine sandy beach.
+        Hugging the slopes of Mont Blanc (Monte Bianco), Courmayeur is Italy’s
+        oldest, and one of its most stylish, ski resorts. North and east of
+        Milan are the romantic lakes Como, Maggiore, and Garda.
+        Milan
+        Quite happy to leave the embroiled politics of national
+        government to Rome, Milan prides itself on being the country’s
+        economic, cultural, and design-conscious capital. Despite its
+        prestigious museums, excellent restaurants and shopping, and
+        magnificent Gothic cathedral, tourists do not think of Milan as an
+        obvious holiday destination (though some do make the pilgrimage just
+        for Leonardo da Vinci’s Last Supper). But anyone interested in
+        contemporary Italian life will want to experience its cafés and clubs,
+        elegant shopping avenues, and side-street art galleries. If the main
+        railway station is an overwhelming homage to Mussolini and fascist
+        design (1925–1931), the Pirelli skyscraper, opposite, (Italy’s first),
+        is a more graceful symbol of the new era. With its vivacious residents,
+        ­fashionable, self-assured and sophisticated — this is modern
+        Italy.
+        Around the Duomo
+        Nowhere does a cathedral more distinctly dominate a major
+        city center. Almost non-stop throughout the day, but especially at that
+        magic moment of the passeggiata, the Piazza del Duomo is one of the
+        liveliest squares in all of Europe. People gather around the cafés,
+        kiosks, and shopping arcades, the young on their cell phones confirming
+        evening plans, the pensionati talking football (soccer) and
+        politics.
+        And all in the shadow of the Duomo, most grandiose of
+        Italy’s Flamboyant Gothic cathedrals. Teams of Italian, French,
+        Flemish, and German architects and sculptors contributed to this
+        astonishing cathedral, begun in 1386 by the ruling Visconti family. For
+        the best view of that awesomely rich façade, finished in 1813, and
+        bristling silhouette of marble pinnacles and statues, stand in the
+        courtyard of the Palazzo Reale south of the cathedral. (It houses the
+        Cathedral Museum, which displays fine examples of Gothic sculpture from
+        the façade. ) The cathedral’s interior is a vast and noble space
+        divided by 52 columns, showing its North European influence in the
+        soaring columns and a decoration of stained-glass windows, from the
+        15th century to the present day.
+        Give yourself plenty of time for a spectacular walk out on
+        the roof. The elevator entrance (clearly signposted outside the
+        cathedral) is in the right transept. Wander high above the city turmoil
+        under the flying buttresses and around the statues (2,245 in all) and
+        forest of pinnacles (135), up to the roof-ridge for an unbeatable view
+        of the city. To go down, take the staircase (158 steps) for some
+        fascinating close-ups of the cathedral’s construction.
+        Leading north from the Piazza del Duomo, the huge
+        cross-shaped shopping arcade of the Galleria Vittorio Emanuele is a
+        splendid steel and glass monument to the expansive commercial spirit of
+        the 19th century, and a prototype of today’s shopping mall. Cafés,
+        restaurants, bookshops, and boutiques are showcased in its unabashed
+        neo-Renaissance décor. The Galleria provides a sheltered, much
+        trafficked pedestrian passage from the Duomo to another holy entity,
+        the revered 18th-century La Scala theater, high temple of opera. Even
+        if you can’t be there for an opera (opening with a gala to end all
+        galas every sacrosanct December 7), attend a concert or dance
+        performance there or at least visit the little museum (left of the
+        theater), if only for a chance to see a strand of Mozart’s hair,
+        Toscanini’s baton, or a peak into the sumptuous Neoclassical auditorium
+        with its six tiers of balconies and galleries.
+        Milan’s most prestigious retail thoroughfare is Via Monte
+        Napoleone, an august parade of Neoclassical palazzi and luxury shops. A
+        grid of narrow side streets such as Via Borgospesso, Via Sant’Andrea,
+        Via della Spiga and Via Bagutta take you into a more tranquil
+        18th-century world, now graced by the overflow of Montenapoleone’s
+        high-fashion stores, art galleries, antique shops, and the town’s
+        smartest trattorie.
+        Around Castello Sforzesco
+        The massive brick fortress, the Castello Sforzesco,
+        northwest of the city center, was originally built by the Visconti and
+        later rebuilt in its present form in the 15th century by Duke Francesco
+        Sforza. The bulk of the solid square structure stands around a vast
+        courtyard, Piazza d’Armiles. Beyond, in the handsome old residential
+        quarters of the Corte Ducale, is the entrance to the Castello Sforzesco
+        Musei Civici, a series of small art museums, devoted to sculpture,
+        painting (Pinacoteca), ceramics, furniture, and archaeology. In
+        collections that include important works by Giovanni Bellini, Mantegna,
+        Titian, Correggio, and Tintoretto, pride of place — and a room to
+        itself — goes to Michelangelo’s last work, the unfinished Rondanini
+        Pietà (1564). Working on it until six days before his death, the
+        sculptor chiselled a pathetic Mary struggling to hold up the dead
+        Jesus, a strange throwback to medieval sculpture for his last tussle
+        with recalcitrant stone.
+        Even without Leonardo da Vinci’s masterpiece in the
+        adjoining refectory, the church of Santa Maria delle Grazie (Via
+        Caradosso, southwest of the Castello) would be worth a visit as a jewel
+        of Renaissance architecture. Adding to an earlier Gothic design, Donato
+        Bramante — Pope Julius II’s chief architect in Rome — fashioned a
+        magnificent red brick and white stone chancel (tribuna) in 1492. The
+        graceful lines of the rectangular choir and 16-sided cupola are best
+        viewed from the little cloister that he built on the north side. Inside
+        the church, stand in the choir to appreciate the majesty of the
+        dome.
+        Leonardo da Vinci’s Last Supper (Cenacolo) has been
+        lovingly resuscitated in the little Dominican refectory to the left of
+        the church. The completion in 2001 of a laborious 20-year restoration
+        helped remove centuries of deterioration and clumsy restoration since
+        it was completed in 1497. More than ever, it unveiled the enormous
+        psychological impact in Leonardo’s depiction of the trauma for each of
+        the disciples when Jesus declares: “One of you will betray me. ” As a
+        result of the painstaking centimeter-by-centimeter recovery of the
+        fragmentary but still powerful traces of the “real Leonardo,” we can
+        now see, for example, that Philip (third to the right) has an
+        expression of acute grief rather than the simpering pathos left by
+        “restorers” who presumed to improve on the original.
+        For another aspect of Leonardo da Vinci’s talents, visit
+        the Science Museum (Museo della Scienza e della Tecnica) housed in a
+        former Benedictine monastery on the nearby Via San Vittore. Among the
+        rooms devoted to the history of science and technology, one gallery is
+        reserved for Leonardo’s inventions, displayed as models constructed
+        from his notebooks. You’ll see his aircraft, a machine for making
+        screws, hydraulic timber-cutter, revolving bridge, various
+        machine-tools, and a system of map-­making by aerial views — created
+        long before any aircraft, even his, was operational.
+        At the eastern end of Via San Vittore, beyond a noble
+        atrium courtyard, the church of Sant’ Ambrogio is the city’s most
+        revered sanctuary, built from the ninth to the 12th centuries. It
+        stands on a foundation that dates back to the time of St. Ambrose
+        (340–397), first bishop of Milan and one of the Church’s four founding
+        fathers with Peter, Paul, and Jerome; his remains are on view in the
+        crypt. Its sober five-bayed façade set the golden standard for the
+        Lombard Romanesque style, flanked by a ninth-century campanile and
+        taller 12th-century tower topped by a modern loggia. In the interior,
+        left of the center nave, notice an 11th-century pulpit standing on a
+        Christian sarcophagus of the Roman era. Under the canopy carved with
+        Romanesque-Byzantine reliefs is the high altar, richly encased in
+        elaborate, bejeweled, and enamelled plates of gold and silver.
+        The Brera and Other Museums
+        The handsome 17th-century palace of the Jesuits is now the
+        Pinacoteca di Brera, one of the country’s foremost art museums of
+        medieval and Renaissance art, concentrating on the master artists of
+        northern Italy. In its fine arcaded courtyard, notice a bronze statue
+        of Napoleon, who was responsible for turning the Brera into a national
+        gallery with confiscations from the Church and recalcitrant nobles.
+        Among the highlights: two paintings by Giovanni Bellini of
+        the Madonna and Child and a highly personal Pietà; Veronese’s Jesus in
+        the Garden; Tintoretto’s dramatic Discovery of St. Mark’s Body; and an
+        impressive Christ at the Column by Donato Bramante.
+        Mantegna has a touching Madonna, but his true masterpiece
+        here is the Dead Christ, achieving a gripping emotional effect with its
+        foreshortened perspective. Piero della Francesca’s celebrated
+        Montefeltro Altarpiece (1474) is his last work. Raphael’s stately
+        Betrothal of the Virgin contrasts with the earthier inspiration of
+        Caravaggio’s Supper at Emmaus.
+        Note the gentle beauty of Correggio’s Nativity and
+        Adoration of the Magi. The non-Italian artists include El Greco,
+        Rubens, Van Dyck, and Rembrandt. In the modern collection, look out for
+        Modigliani, Boccioni, de Chirico, Carrà, and de Pisis. Enjoy the Brera
+        neighborhood, Milan’s “Greenwich Village,” after your museum visit; it
+        has been regentrified in the last decades and now offers cutting-edge
+        quaintness in its trendy boutiques, stylish cafés and reputed art
+        galleries.
+        The Biblioteca Ambrosiana (Piazza Pio XI) has reopened in
+        the newly restored 17th-century palace and library of Cardinal Federigo
+        Borromeo. Its principal treasure, though of contested provenance, is
+        Leonardo da Vinci’s luminous Portrait of a Musician (1485), unfinished
+        but at the same time the best preserved of the master’s few surviving
+        works. You can see his pervasive influence on Milanese artists in the
+        decorative paintings of Bernardino Luini and a fine Portrait of a Young
+        Woman by Ambrogio de Predis. Caravaggio’s only still life, Bowl of
+        Fruit, is here. Travelers on their way to or from Rome will be
+        especially interested in Raphael’s cartoons (preparatory drawings) for
+        his School of Athens fresco in the Vatican.
+        The Poldi-Pezzoli Museum (Via Manzoni 12) is a small,
+        formerly private collection displayed in the charming ambience of its
+        original home dedicated to the city in 1881. The prize pieces of this
+        stunning collection include Piero della Francesca’s San Nicola da
+        Tolentino, Mantegna’s Madonna and Child, a Botticelli Madonna, and
+        Antonio Pollaiuolo’s lovely Portrait of a Young Woman.
+        Lombardy
+        The central part of the Po valley is only a fraction of
+        the Italian lands conquered by the Lombards when they crossed the Alps
+        from eastern Europe in the early Middle Ages. But it proved to be the
+        most fruitful, all too tempting to the acquisitive appetites of France,
+        Spain, and rival Italian duchies and city-states such as Venice, which
+        pushed its Serene Republic as far west as Bergamo. Natural fertility
+        was enhanced by Europe’s most advanced systems of irrigation, still
+        operating in the medieval canals that you’ll see on your way south to
+        Pavia. Lombardy’s rice, wheat, and maize are the basis of the nation’s
+        risotto, pasta, and polenta.
+        On a more sentimental note, Italy’s Lake District at the
+        foot of the Lombardy Alps — its major lakes are Como, Garda and
+        Maggiore — is the perfect setting for mending broken hearts, breaking
+        mended hearts, and all romantic conditions in between.
+        Pavia
+        The Lombards’ first capital, before Milan, is now a
+        sleepy, well-preserved, redbrick university town. Its principal
+        attraction, the spectacular Charterhouse or Certosa di Pavia, is in
+        fact some 10 km (6 miles) north of the city, a 30-minute drive from
+        Milan. Built by the powerful Gian Galeazzo Visconti, Duke of Milan, as
+        his family’s burial chapel, the Carthusian monastery’s 15th-­century
+        church is a high point in the transition from Flamboyant Gothic to
+        Renaissance. Even without the originally designed crowning gable, the
+        sculpted multi-colored marble façade makes an impact, with statues of
+        prophets, saints, and apostles above the medallion reliefs of Roman
+        emperors.
+        The massive Gothic interior is lightened by the brightly
+        colored paving and groin-vaulting. A­mong the chapels which were given
+        Baroque finishings in the late 16th century, notice an exquisite
+        Perugino altarpiece of God the Father. Right of the triumphant Baroque
+        high altar is a beautifully carved 15th-century lavabo (ritual basin)
+        and a charming Madonna and Child by Bernardino Luini. In the right
+        transept is the Visconti tomb, and a door leading to the lovely small
+        cloister of russet terracotta, with a fine view of the church’s
+        galleried octagonal tower. Since 1947, Cistercians have taken over from
+        the Carthusian monks living in an adjoining cloistered wing, but
+        continue to manufacture Certosa’s well-known Chartreuse liqueur and
+        herbal soaps in an adjoining shop.
+        Bergamo
+        Rising out of the plain of the Po valley on its own steep
+        little hill, 47 km (29 miles) east of Milan, the delightful town of
+        Bergamo is known as the 16th-century home of the Commedia dell’Arte.
+        Founded by the ancient Romans, the city has a proud soldiering history,
+        giving the Venetian Republic a famous condottiere, Bartolomeo Colleoni,
+        and the largest contingent in Garibaldi’s 1,000 Red Shirts. The
+        pleasant Città Bassa (lower city) at the foot of the hill is the
+        attractive, modern town full of shops, hotels, and restaurants known
+        for a savory rendition of risotto they insist is superior to Milan’s.
+        Piazza Matteotti is the hub of the new town’s lively café scene, along
+        the Sentierone arcades. Opposite is the Teatro Donizetti and a monument
+        showing the famous opera composer who was born here in
+        1797 — accompanied by the naked lady he is said always to have needed
+        for inspiration.
+        One of Italy’s finest, the Galleria dell’Accademia Carrara
+        has an important Mantegna Madonna and Child and interesting works by
+        Lotto (a Venetian master who spent many years living in Bergamo),
+        Bellini, Raphael, and Titian as well as foreign masters.
+        Venetian ramparts still protect the historic Città Alta
+        (Upper City) on the hill, the older section of town linked to the Città
+        Bassa by funicular. The gracious Piazza Vecchia is surrounded by
+        Renaissance public edifices, notably the Palazzo della Ragione with a
+        medieval Torre del Comune. The town’s most venerable edifice is the
+        12th-century Romanesque basilica of Santa Maria Maggiore. Notice the
+        finely carved monumental north porch and slender campanile. The Baroque
+        interior has impressive 16th-century tapestries, inlaid wooden choir
+        stalls, and beautiful intarsia work at the altar rail. Adjacent to the
+        church is the Renaissance Colleoni Chapel, an extravagant mausoleum in
+        red, white, and green marble with ceiling frescoes by Tiepolo.
+        Lake Garda (Lago di Garda)
+        On the lake’s west shore, the people of Salò (where
+        Gaspare Bertolotti is regarded as the originator of the violin) suggest
+        that his design was inspired by the contours of the lake. But Italy’s
+        largest and eastern-most lake is actually shaped more like a banjo, 52
+        km (32 miles) from the ruggedly romantic cliffs of the neck down to its
+        broad “sound box,” 18 km (11 miles) across, surrounded by rolling green
+        hills and gardens. Graced with vineyards (notably Bardolino), lemon
+        trees, olives, and cedars, the lake enjoys mild winters and mellow
+        summers.
+        At the south end, boat cruises start out from Peschiera,
+        Sirmione, and Desenzano, particularly recommended for dramatic views of
+        the east shore’s mountains and the beautiful Punta di San Vigilio, with
+        its little church and 16th-century Villa Guarienti. Begin your road
+        tour out on the narrow Sirmione promontory. This former fishing village
+        and renowned spa resort is the most popular of Garda’s towns, and
+        affords a splendid view of the lake from the tower of the 13th-century
+        moated and turreted castle, the Rocca Scaligera. The drive itself,
+        along the winding Gardesana Occidentale, which cuts through the cliffs
+        of the west shore, is spectacular. The resort town of Gardone Riviera
+        is much appreciated for its parks and botanical gardens and as a base
+        for hikes back into the hills. Above the resort, in Gardone di Sopra,
+        is a 20th-century “folly,” Il Vittoriale, the bizarre and disturbing
+        hillside residence of Gabriele D’Annunzio — poet, adventurer, fascist.
+        He died here in 1936: Melancholy gardens of dark laurel and cypresses
+        lead up to a hilltop mausoleum of the writer’s sarcophagus flanked by
+        those of his disciples. It overlooks the prow of a patrol boat that
+        D’Annunzio commanded during WWI, the Puglia, hauled up the hillside as
+        the crowning piece of his relics.
+        Lake Como (Lago di Como)
+        Embraced by green wooded escarpments and backed by
+        snow-capped Alps, the lake favored by some of England’s most romantic
+        19th-century poets — Words­worth, Shelley, and Byron — retains a
+        certain wistful atmosphere for the leisure hours of the Milanese (it’s
+        less than an hour from Milan by train or car). As at Garda, a mild
+        climate nurtures luxuriant vegetation in the villa gardens and
+        parks.
+        The lake dramatically divides into two arms on either side
+        of the pretty resort town of Bellagio, which juts out on a hilly
+        promontory. Up on the heights above the town, the elegant 18th-century
+        Villa Serbelloni stands in the middle of a beautiful park of rose
+        trees, camelias, magnolias, and pomegranates. Now in the hands of the
+        Rockefeller Foundation, its famous gardens can be visited by guided
+        tour. Don’t confuse the Villa Serbelloni with the luxury lakefront
+        hotel of the same name.
+        The lake’s southwest arm is the most attractive for your
+        excursions. From Lezzeno, take a boat cruise to see the colorful
+        grottoes, and look for the waterfall at Nesso. Como itself is a large
+        factory town famous for its centuries-old silk production, but it has a
+        handsome Gothic-Renaissance cathedral crowned by a superb Baroque dome
+        that was added in 1744 by Turin’s great architect, Filippo Juvarra. It
+        stands next to the arcaded and half-timbered Broletto, 13th-century
+        seat of municipal government.
+        The western shores of the lake are lined with gracious
+        villas nestling in perfumed gardens. At Cernobbio, the 16th-century
+        Villa d’Este is now a landmark 5-star hotel, one of Europe’s most
+        special. Come at least for tea or a stroll among the cypresses and
+        magnolias. Between the genteel resort towns (and ferry stops) of
+        Tremezzo and Cadenabbia, you’ll find one of the lake’s most beautiful
+        and famous residences (open to the public), the 18th-century Villa
+        Carlotta. There’s a marvelous view of the lake from its terraced
+        gardens, much visited for the display of camelias, rhododendrons, and
+        azaleas in late April and May.
+        Lake Maggiore
+        The northern, more blustery end of the lake is in
+        Switzerland, but the Italian side shares the other lakes’ mellow
+        climate. The resort towns offer excellent opportunities for relaxation
+        and sports on longer stays, but for short visits you’ll get a better
+        idea of the lake aboard a boat cruise (3–4 hours, with a meal on board,
+        from Stresa, Baveno, or Pallanza) than by road.
+        Stresa is Maggiore’s principal resort. The lakeside
+        promenade, Lungolago, is famous for its flowers and bewitching view of
+        the lake’s islands. Take the cable car to the peak of the Mottarone at
+        1,491 m (4,892 ft) for an exhilarating view of the Lombardy lakes, the
+        Alps, and the Po valley. A toll road will also take you there via the
+        Giardino Alpinia (Alpine Garden), which displays over 2,000 varieties
+        of mountain plants.
+        The most popular boat trip from Stresa is to the Borromean
+        Islands (Isole Borromee) (the 5-star hotel in Stresa of the same name
+        was the setting for Hemingways’ Farewell to Arms), celebrated for their
+        Baroque palazzi and magnificent gardens. They are still the property of
+        the Borromeo family that provided Milan with its greatest cardinals.
+        The 17th-century palazzo on Isola Bella is decorated with admirable
+        paintings by Annibale Carracci, Tiepolo, Zuccarelli, and Giordano. The
+        luxuriously planted terraced gardens constitute one of the finest
+        ensembles of the Italian formal style. View the lake from the uppermost
+        of the ten terraces, by the unicorn statue that is the Borromeo family
+        emblem. Isola dei Pescatori (a.k.a. Isola Superiore) is a delightfully
+        peaceful fishing village with tiny narrow streets, while Isola Madre,
+        farther out in the lake, is the largest and most peaceful of the
+        islands. It might pass for deserted, if not for the peacocks and
+        pheasants who inhabit the botanical gardens, and the visitors strolling
+        amidst the palms and rhododendrons.
+        Piedmont (Piemonte)
+        As its name suggests, this region of the fertile upper
+        basin of the Po river lies in the foothills between the Appenines and
+        the Alps at the French and Swiss borders.
+        From the fall of the Roman Empire to the 19th century, it
+        stood outside the mainstream of Italian history. Its royal House of
+        Savoy walked a diplomatic tightrope between the rivalries of France,
+        Switzerland, Spain, and the German emperors until the fall of Napoleon.
+        The new nationalism led Piedmont into the Italian orbit at the head of
+        the Risorgimento unification movement, and the House of Savoy served as
+        Italy’s reigning royal family from 1861 to 1946, with Turin serving
+        ever so briefly as the capital of the newly unified Italy in 1861.
+        Close links to France have left their mark. A French
+        patois-like dialect is still spoken in some hill villages and you’ll
+        notice bilingual street signs in the Aosta Valley (geographically part
+        of Piedmont, but administratively separate). For example, Courmayeur,
+        the country’s most venerable ski resort, never adopted its more Italian
+        name of Cortemaggiore. The classical palaces and squares of Turin,
+        Piedmont’s royal capital, are in many ways closer in spirit to France
+        than the rest of Italy. But whatever Gallic ambience this may have
+        created has been thoroughly “Italianized” by the steady influx of
+        workers from the south for the steel, chemical, automobile, and
+        communications industries.
+        Turin (Torino)
+        Best known for its industry, most notably the giant Fiat
+        and Pirelli works, the proud Piedmontese capital is far from being a
+        dull or dismal factory town. It has retained the grid-like layout of
+        its origins as Taurinorum, a Roman castrum. Its rise to prominence in
+        the 17th and 18th centuries was accompanied by Italy’s first coherent
+        urban planning; classical and Baroque palaces and monuments give its
+        main streets and squares a great dignity and panache augmented by the
+        city’s economic prosperity.
+        The tone is set by the formal elegance of the Piazza
+        Castello, dominated by Filippo Juvarra’s richly articulated Baroque
+        façade for the Palazzo Madama. The original medieval castle received
+        its new name when transformed in the 17th century into the royal
+        residence of Vittorio Amedeo I’s widow, nicknamed “Madama Reale,” a.k.a
+        Maria Cristina of France. It now houses the Civic Museum of Ancient Art
+        (Museo Civico di Arte Antica) beside a splendid ceremonial staircase,
+        also designed by Juvarra. The paintings include Jan Van Eyck’s
+        14th-century miniatures for the Book of Hours of the Duc de Berry,
+        Pontormo’s St. Michael, and a particularly handsome Portrait of a Man
+        by Sicilian master Antonello da Messina. On the upper floors are the
+        royal collections of furniture, ceramics, and carved ivories.
+        Across the square is the former royal chapel, the
+        17th-century church of San Lorenzo, designed by Turin’s other great
+        Baroque architect, Fra Guarino Guarini. Philosopher and mathematician
+        as well as priest, he has created a marvelously intricate interior
+        surrounding the octagonal space with 16 red marble columns. Arches rise
+        to hold the central lanterned cupola formed by an 8-pointed star.
+        The Royal Palace (Palazzo Reale) was the ornately Baroque
+        home of the Savoy princes from the mid-1600s to 1865. After strolling
+        through one sumptuous room after another, visit the wing that houses
+        the Armory (Armeria Reale), for a look at the important collection of
+        Asian and European weapons and armor dating back to Roman and Etruscan
+        times. It is one of the most comprehensive of its kind in Italy. Then
+        relax a while behind the Palazzo Reale in its Royal Gardens (Giardini
+        Reali), designed by Louis XIV’s Tuileries and Versailles
+        landscape-architect, André Le Nôtre.
+        The late 15th-century cathedral (Duomo di San Giovanni)
+        cherishes one of Italy’s most celebrated (and controversial) relics,
+        the shroud said to have wrapped Jesus after his descent from the cross,
+        taking the imprint of his face and body. Sometimes enshrined in the
+        Chapel of the Holy Shroud (Cappella della Santa Sindone), it was
+        brought to Turin in the 17th century after a journey 200 years earlier
+        from Jerusalem to France via Cyprus. Measuring 4.1 by 1.4 m (13 by 5
+        ft), the sheet is kept in an iron-lined silver casket placed in a
+        marble urn and tucked away in the Museo della Sidone, and is rarely on
+        display to the public (with the recent exception of the Holy Year
+        2000). During the occasions that it is on display, it is brought to the
+        chapel. Many dispute the modern scientific tests that have proven it to
+        be a medieval fabrication, and crowds of faithful and merely curious
+        still visit its black marble chapel, a masterpiece of Guarini’s High
+        Baroque, with its cone-shaped, six-tiered dome formed by a web of
+        intersecting arches that rise to a 12-pointed star. It was recently
+        restored after a 1997 fire that left the city, and the nation, alarmed
+        at how close it came to being completely destroyed.
+        The pride of Turin, as in so many Italian cities, is not
+        in one monument but in a glorious square, the Piazza San Carlo and
+        Piazza Santa Cristina, one of the most beautiful in Europe. The
+        17th-century palazzi make an exquisite setting for your late afternoon
+        passeggiata along the arcades of shops and cafés, culminating in the
+        graceful symmetry of two Baroque churches, Juvarra’s Santa Cristina and
+        its twin, San Carlo. Stretching north and south of the square is the
+        town’s most elegant shopping street and main axis, Via Roma.
+        Northeast of the piazza, in the Palazzo dell’Accademia
+        delle Scienze, is the Egyptian Museum (Museo Egizio), second in
+        importance only to the one in Cairo. The Savoys’ collection of more
+        than 30,000 items is on display, including priceless treasures such as
+        the staggering variety of statues of the Pharaohs of the period around
+        1500 b.c. Smaller artifacts of everyday life are just as
+        fascinating — combs, clothes, kitchen utensils, even food found in a
+        well-preserved 14th-century b.c. tomb.
+        Pace your stamina for the second floor’s excellent
+        Galleria Sabauda (Savoy Gallery), with an important collection of
+        Italian and European art, also due to the Savoys’ penchant for
+        collecting. The Italian works include a Fra Angelico Virgin and Child,
+        Vero­nese’s Supper at Simon’s House, and Pollaiuolo’s Tobias and the
+        Archangel. But the Savoys also favored the Flemish, Dutch, and Northern
+        European paintings, making this collection one of Italy’s richest. It
+        includes Jan Van Eyck’s St. Francis Receiving the Stigmata and works by
+        Roger Van Der Weyden, Van Dyck, Rembrandt, Hans Memling, and François
+        Clouet.
+        One of the city’s more bizarre monuments is the Mole
+        Antonelliana, with its swordfish-like 167-m- (547-ft-) high granite
+        spire, named after its engineer designer Alessandro Antonelli. Planned
+        originally in 1863 as a synagogue and for many years the world’s
+        tallest building, it’s now a beloved city icon used for exhibitions and
+        elevator trips to its panoramic terrace.
+        Automobile buffs from all over the world come to check out
+        the Italian designing talents of Fiat, Alfa Romeo, Bugatti, and Ferrari
+        (but also Benz, Peugeot, and Ford) celebrated out at the Museo
+        dell’Automobile (Corso Unità d’Italia, 40), south of the city center
+        beside the Po river.
+        Take the pretty excursion up on a hill across the river to
+        Sassi, 10 km (6 miles) east of Turin, to see Juvarra’s Baroque
+        masterpiece, the splendid domed Basilica di Superga completed in 1731
+        and the hilltop view of Turin, the Alps, and the Po Plain. It is
+        something of a pantheon for the House of Savoy, buried in the
+        basilica’s Crypt of Kings.
+        Courmayeur
+        The 4,810-m (15,781-ft) peak of Mont Blanc (Monte Bianco)
+        may be in France, but the Italian side of the mountain gets the better
+        weather. The Aosta Valley’s Courmayeur is as pleasant a base for
+        hiking — and more strenuous mountain-climbing — in summer as it is for
+        skiing in winter. This is Italy’s oldest ski resort and an Alpine
+        Museum traces its history in the Casa delle Guide (Maison des Guides).
+        With fine hotels and fashionable boutiques, Courmayeur’s lost innocence
+        is easily captured in Entrèves, its quiet, little-sister neighbor 3 km
+        (2 miles) to the north.
+        One of the most spectacular excursions in the whole
+        country is the dramatic cable car ride from La Palud, north of
+        Courmayeur, to the Colle del Gigante, 3,354 m (11,004 ft) and Aiguille
+        du Midi, 3,842 m (12,606 ft) down to Chamonix in France. You’ll have
+        breathtaking views across to the peak of Mont Blanc and the whole roof
+        of the western Alps. (The Aiguille cable car station is across the
+        French border, so take your passport if you care to descend at any
+        point on French soil. )
+        Italian Riviera
+        The Ligurian coast that holidaymakers have dubbed the
+        Italian Riviera has an ancient history of piracy and commerce, not
+        always easily distinguishable. The great port city of Genoa made the
+        Mediterranean more or less safe for respectable traders, and the rest
+        of the coast settled down to some quiet fishing, sailing, and harmless
+        traffic in postcards and suntan lotion.
+        The picturesque, more rugged coast east of Genoa is known
+        as the Riviera di Levante (Riviera of the Rising Sun), while the coast
+        west to the French border at Ventimiglia is the Riviera di Ponente
+        (Riviera of the Setting Sun), better known for the sandy beaches of its
+        family resorts.
+        Genoa (Genova)
+        Hemmed in between the Apennine mountains and the sea, for
+        centuries Genoa tended, like historic rival Venice on the east coast,
+        to turn its back on Italy and seek its fortune on the high seas. This
+        may account for a cool reserve, almost aloofness, that some read even
+        into the architecture of the tall houses in the straight and narrow
+        streets behind the port.
+        With 28 km (17 miles) of docks, Italy’s biggest port
+        remains the key to the city’s identity. As an important maritime center
+        for the Roman Empire, Genoa would later be put on the map of sea-faring
+        annals forever as the birthplace of Christopher Columbus. The
+        quincentennial anniversary celebrating his 1492 voyage saw the city’s
+        historical port undergo a face-lift, and the addition of the Aquarium,
+        the largest in Europe, a must-see for visitors with children.
+        The main shopping street of this little-visited city is
+        Via XX Settembre west of the Piazza De Ferrari that constitutes the
+        city’s bustling modern center, where the city’s historic quarters
+        begin. Piazza San Matteo was the medieval home of the august Doria
+        family, navigators and merchants who helped build the city’s great
+        commercial empire. Their arcade houses, with gray-and-white striped
+        façades (numbers 15–17) were built from the 13th to 15th century. The
+        Romanesque-Gothic church of San Matteo has the same gray-and-white
+        façade. In the crypt, you’ll find the tomb of Andrea Doria, great
+        16th-century admiral who took Genoa into the Spanish camp against the
+        French and became the city’s virtual dictator.
+        The Renaissance and Baroque palaces of the Via Garibaldi
+        are a unique testimony to the town’s historic prosperity, many of them
+        now banks or museums. The Palazzo Bianco (number 11) makes a handsome
+        setting for Genoa’s most important art collection, mostly the work of
+        Genoese painters: Cambiaso, Strozzi, and Magnasco, as well as works by
+        Pontormo and Palma il Vecchio, and the Flemish school —  Rubens, Gérard
+        David, and Van Dyck. The 17th-century Baroque Palaz­zo Rosso (number
+        18), taking its name from the red façade, displays works by Veronese,
+        Titian, Caravaggio, Dürer, Rubens, and Van Dyck.
+        Not only did his home town not finance his crazy trip to
+        America, but Genoa still has no decent monument to Christopher
+        Columbus. The closest reference you’ll find is on a ramp leading to the
+        Port a Soprana, a medieval turreted gate on Piazza Dante, where there
+        is an obscure plaque indicating the house of the discoverer’s
+        father.
+        Riviera Resorts
+        Along the mostly rugged Riviera di Levante east of Genoa,
+        by far the prettiest spot is tiny Portofino, seemingly more fishing and
+        sailing harbor than resort, but look and you’ll find some fine hotels
+        and private villas back in the forest-covered hills. From the
+        colorfully painted houses clustered around the postage stamp-sized
+        harbor, avoid the crowds of day-trippers by setting out on a paved
+        cliff walk. Pass the yellow-painted church of San Giorgio to the
+        lighthouse (faro) at the end of the government-protected Promontory
+        Monte Portofino for a superb view along the coast. The cliffs are
+        clothed in a profusion of exotic vegetation, with occasional glimpses
+        of private homes framed by cypresses, palm trees, and cascades of
+        bougainvillaea. Boat excursions will take you to other beautifully
+        secluded villages, such as the historic monastery of San Fruttuoso,
+        reachable only by boat or a 2-hour walk, and delightfully unspoiled
+        Camogli. By foot, you can also visit the charming little fishing hamlet
+        of San Rocco and take a 40-minute walk over to Punta Chiappa, looking
+        out over the whole Riviera. A favorite boat ride from Santa Margherita
+        is the cluster of former fishing villages called the Cinque Terre,
+        cliff-clinging hamlets hugging a stretch of coastline reminiscent of
+        the Mediterranean one hundred years ago. Reachable only by boat until
+        recently, they are linked by a network of ancient cliffside mule paths
+        that provide some of Italy’s loveliest treks.
+        Santa Margherita Ligure is a lively resort town full of
+        cafés, boutiques, good hotels, and a palm-lined waterfront esplanade
+        with seafood-serving trattorie. It absorbs the tourism neighboring
+        Positano cannot accommodate. The family resort of Sestri Levante has
+        fine sandy beaches. Most popular of all, down the coast beyond the
+        naval city of La Spezia, are the beaches of Viareggio, favorite Tuscan
+        resort, together with its more up-market neighbor, Forte dei Marmi.
+        Cool off with an excursion inland to Carrara, where the
+        marble quarries provided the raw material for Italy’s greatest
+        achievements, the monuments of the Roman Empire and the Renaissance.
+        The town is still full of sculptors, and Piazza Alberica is the scene
+        of a summer sculpture competition — 14 days to produce a masterpiece.
+        Visit the still active quarries of Fantiscritti and Colonnata. The
+        marble that Michelangelo chose for his Moses and Pietà is now hewn, at
+        $3,000 a cubic meter, for replicas at Caesar’s Palace in Las Vegas,
+        tombstones in the Los Angeles Forest Lawn cemetery, and countless homes
+        of oil-rich sheiks.
+        The Riviera di Ponente, west of Genoa toward the French
+        border, is an almost continuous chain of family resorts. A faded resort
+        of earlier times, dignified San Remo is the best known, with its
+        well-heeled casino and elegant promenade along the Corso Imperatrice.
+        For time away from the beach, explore the narrow, winding medieval
+        streets of the hilltop La Pigna quarter, leading up to the 17th-century
+        sanctuary of Madonna della Costa.
+        The quieter resort of Bordighera is particularly proud of
+        the palm trees along the Lungomare Argentina promenade. Since the 16th
+        century, the town has had the exclusive privilege of providing Rome
+        with its palm fronds for the Sunday before Easter. Alassio completes
+        this coast’s trio of major resorts, justifiably proud of its gardens
+        nurtured by a particularly mild winter. Take an excursion east to the
+        quiet medieval town of Albenga, with its Romanesque-Gothic houses
+        around the 11th- to 14th-century cathedral and early Christian
+        (fifth-century) baptistery.
+        THE SOUTH
+        One of the great joys of the south is the extent to which
+        it is still virgin land for the majority of Italy’s visitors. It has
+        its perennial favorites: the sister islands of Capri and Ischia in the
+        Bay of Naples, the ruins of Pompeii, and the resorts of the singularly
+        beautiful Amalfi coast. Otherwise, southern Italy is overlooked by
+        tourists almost as much as it has been by the national government since
+        the 1871 reunification. Less prosperous than the north, it cannot offer
+        the same wealth of modern hotel facilities. Monuments and museums have
+        suffered from earthquakes (the last catastrophic one was in Campania
+        1980), and civic neglect. But things are slowly improving and the
+        compensations for the more venturesome visitor are considerable. The
+        chief pleasure of the south, or Mezzogiorno, is the people, who are
+        warm-hearted, outgoing, and gregarious.
+        Naples (Napoli)
+        The very idea of this teeming, undisciplined town once
+        intimidated the faint-hearted, but the last decade has seen interesting
+        change in this history-rich city of which the enterprising and cheerful
+        Neapolitans are justifiably proud. For adventurous travelers looking
+        for an introduction to the South, the rewards are rich. Indeed, two of
+        Naples’ museums are among the most important in Europe, but they and
+        the piazzas and monuments play second fiddle to the colorful street
+        life. In the outdoor theater that is Italy, Naples is unabashed
+        melodrama: around the port, the popular quarters of Spaccanapoli, even
+        the more bourgeois neighborhoods of Vomero and Posillipo. You’ll want
+        to spend hours in the restaurants. Naples is where pizza began (the
+        region is the nation’s number one supplier of mozzarella), and
+        flavorful home-cooking of fresh ingredients has been raised to an art
+        form.
+        The cautious tell you not to drive in Naples, where
+        one-way signs are meaningless, parking is impossible, traffic is
+        relentless, and red and green lights can be purely decorative. They are
+        right.
+        The face of Naples has been made and remade by its many
+        earthquakes, permitting — imposing — transitions from Gothic to
+        Renaissance and Baroque. Many of the city’s churches, palaces, and
+        museums still show signs of ongoing reconstruction and restoration
+        after the devastating earthquake of 1980.
+        The Port and Spaccanapoli
+        Traffic roars down the broad Corso Umberto I to the
+        pivotal Piazza Municipio to serve the docks or spin off into the
+        commercial district behind Santa Lucia, the teeming historic center of
+        Spaccanapoli, or the residential districts of Vomero and Posillipo.
+        Towering over the long rectangular square on its south
+        side is the massive dry-moated Castel Nuovo. Originally the
+        13th-century fortress of Naples’ French ruler Charles d’Anjou, it was
+        rebuilt in the 15th century as a palace for the Spanish kings of
+        Aragon. Entrance to what is now administrative offices and a communal
+        library is between two towers on the west side, away from the harbor,
+        through a fine two-story Renaissance triumphal arch crowned by a statue
+        of St. Michael.
+        Celebrated in song, the old popular harbor district of
+        Santa Lucia is now lined with elegant hotels and restaurants, many
+        overlooking the formidable medieval Castel dell’Ovo on its own islet,
+        with a handful of outdoor trattorias and cafés that enjoy a unique
+        setting. The waterfront walk at sunset offers timeless views of the bay
+        and Mount Vesuvius, with the contemporary addition of a gleaming-white
+        cruise ship or two. At the workaday zone of Mergellina at the western
+        end of the harbor, the fishermen bring their morning catch into Porto
+        Sannazaro.
+        South of the Piazza Municipio, the Via San Carlo curves
+        round to the 19th-century steel-and-glass shopping arcade of Galleria
+        Umberto I, opposite the great Neoclassical temple of Neapolitan bel
+        canto, the Teatro San Carlo opera house. First built in 1737 and
+        rebuilt in 1816, it holds the distinction of once being under the
+        musical direction of Gioacchino Rossini (1815–1822) and still
+        possessing some of the finest acoustics in Europe. The solemnly
+        monumental hemicycle of the Piazza del Plebiscito was laid out by
+        Napoleon’s marshal Joachim Murat, when as King of Naples, he occupied
+        the Spaniards’ Palazzo Reale on the east side of the piazza. The rooms
+        are still decorated and furnished with the Baroque pomp of the 17th and
+        18th centuries and reconstructed following Allied bomb damage in 1943.
+        Its sumptuous royal apartments are the draw, but it also features
+        temporary exhibits.
+        Leading north from the palace, the Neapolitans’ favorite
+        shopping street of Via Toledo separates the town hall (Municipio) and
+        the broad commercial streets going down to the harbor from a
+        checkerboard of narrow alleys to the west, a Spanish neighborhood of
+        the 16th century that is now a mass of dilapidated working-class
+        housing and a great opportunity for watching everyday-life.
+        Via Toledo takes you into the city’s historic heart,
+        Spaccanapoli (around a Roman road that “splits Naples” into upper and
+        lower districts). In an area stretching from the permanently
+        traffic-jammed Piazza Dante, between Via San Biagio dei Librai and Via
+        Tribunali and over to the Porta Capuana, the popular image of old
+        Naples survives. A permanent festival of laundry hangs across the
+        narrow streets. Gossip, business, and family arguments fly between
+        balconies, while ropes haul up baskets of vegetables, letters, and pet
+        cats.
+        For a sense of the historic neighborhood’s old splendor,
+        start on Piazza Gesù Nuovo, with its characteristically extravagant
+        Baroque Immacolata column (guglia) in the center. Behind an embossed
+        façade, the same architectural exuberance continues inside the Jesuit
+        church. But the jewel here, on the south corner of the square, is the
+        14th-century Gothic church of Santa Chiara, built for the wife of
+        Robert the Wise d’Anjou and retrieved from its 18th-century Baroque
+        additions and 1943 firebombing. The original rose window and elegant
+        porch survive and the French Gothic interior is beautifully restored. A
+        number of sculpted tombs include the sculpted tombs of Marie de Valois
+        (on the right) and Robert the Wise d’Anjou (d. 1343; behind the high
+        altar). Next to the church are the lovely 14th-century cloisters
+        (Chiostro delle Clarisse), converted in 1742 into a country garden of
+        shaded walkways and Capodimonte ceramic tiles — a delightful haven of
+        tranquility and one of Naples’ most charming spots.
+        Take the Via Tribunali to the Franciscan church of San
+        Lorenzo Maggiore, with its Baroque façade incorporating the
+        14th-century marble porch, which was added after the earthquake of
+        1731. Inside, the sober French Gothic chancel, exceptional in Naples
+        for its ambulatory around the nine chapels, contrasts with the Baroque
+        chapel left of the choir.
+        The cathedral’s three original 14th-century portals are
+        somewhat overpowered by the 19th-century neo-Gothic façade. Inside,
+        left of the Baroque nave, go down to Naples’ earliest known Christian
+        sanctuary, the fourth-century Ba­si­li­ca of Santa Restituta, in which
+        the original Roman columns survived the 1688 earthquake. At the end of
+        the right nave is the fifth-century domed baptistery, one of the oldest
+        buildings known in Christian Europe with some original mosaics still
+        intact. The cathedral’s richly Baroque Chapel of San Genaro is the
+        highlight, its altar containing two phials of Naples’ beloved patron
+        saint’s blood. On his much awaited feastday held twice annually (the
+        first Sunday of May and 19 September), the blood is said to liquify,
+        even “boil”: When it doesn’t, disaster befalls Naples. The last time it
+        is said to not have liquified was 1980, the year of the great
+        earthquake. Scientists don’t have an answer for this one.
+        The Museums
+        The roguish image of the city’s present might make it easy
+        to forget the city’s glorious past. Luckily, two truly magnificent
+        museums preserve the region’s treasures from the ravages of earthquake
+        and theft.
+        Originally a 16th-century cavalry barracks, the
+        Archaeological Museum (Museo Archeologico Nazionale) is in no way a dry
+        bundle of old bones and stones, but sheer pleasure for anyone even
+        remotely interested in southern Italy’s Greek, Etruscan, and Roman
+        past. All visits to Pompeii and Herculaneum should begin or end here,
+        since the world-famous collections beautifully display not only the
+        paintings and mosaics buried there nearly 2,000 years ago by Mount
+        Vesuvius, but a host of other sculptures from the region’s villas and
+        temples, brought here for safe-keeping.
+        The ground floor is devoted to sculpture, including many
+        Roman copies of classics from Greece’s Golden Age in the fifth century
+        b.c. , which are our only access to these lost masterpieces. The most
+        famous of these is the Doryphorus (Spear-carrier) of Polycletus, second
+        in fame among Greek sculptors only to Phidias. The Emperors’ Gallery
+        includes busts and statues of Julius Caesar, Augustus, Claudius, and
+        Caracalla.
+        Most popular are the stunning Pompeii mosaics and
+        Herculaneum bronzes on the mezzanine floor. The lively secular and
+        pagan mosaics from Pompeii’s patrician villas make a striking contrast
+        with the rigid formality of church mosaics that we see elsewhere in
+        Italy. They include Clients Consulting a Sorceress and Strolling
+        Musicians, vivid little friezes of an octopus, a cat catching a quail,
+        and the huge exciting mural of Alexander driving Darius of Persia from
+        the battlefield at Issus in 333 b.c. The paintings here are the best
+        preserved of any from Roman antiquity — frescoes in brilliant blues,
+        greens, and the inimitable Pompeii reds. The most celebrated is the
+        sophisticated portrait of Paquius Proc­ulus and his Wife, depicting an
+        interracial marriage. Also look for the elegant Hercules and Telephus
+        and four delicate portraits of women, including Artimedes and the
+        Flower Gatherer. Opened in 2000, the Gabinetto Segreto (Secret Gallery)
+        displays a small but discerning collection of mosaics and paintings,
+        many never before seen because of their controversial nature. It can be
+        visited by guided tour only, arranged upon the purchase of your ticket
+        at the museum entrance.
+        The Capodimonte Museum, reopened in 2000, is housed in a
+        beautifully restored 18th-century hilltop palace. The grounds offer a
+        welcome rest before and after a visit to the rich and handsomely
+        re-hung collection of Italian and European paintings.
+        Highlights include: Giovanni Bellini’s gentle
+        Transfiguration of Christ standing serenely between Moses and Elijah;
+        Mantegna’s Portrait of a Boy; and Michelangelo’s drawing of Three
+        Soldiers for his Vatican fresco of St. Peter’s Crucifixion. The Titian
+        room contains half a dozen of his great works, among them a brilliant
+        Pope Paul II with his Farnese Nephews, the artist’s daughter Lavinia
+        Vecellio and Philip II of Spain. The stark realism you’ll see in
+        Caravaggio’s Flagellation and the Seven Works of Mercy launched a whole
+        Neapolitan school of “Caravaggeschi” displayed here. Most notable among
+        the museum’s non-Italian painters are El Greco, Breughel (Blind Leading
+        the Blind and the Misanthrope), Cranach, Holbein, Dürer, and a Van Dyck
+        Crucifixion.
+        Vomero and Posillipo
+        Much of Naples’ middle class looks out over the city from
+        the hilltop Vomero neighborhood in geometrically laid out, treeshaded
+        streets respectably named after artists and musicians of the
+        Renaissance and Baroque periods: Michelangelo, Giordano, Scarlatti, and
+        Cimarosa. On the southeast edge of the Vomero hill just below the
+        massive Castel Sant’­Elmo, the elegant Baroque Charterhouse Certosa di
+        San Martino offers a soothing haven of tranquility in its cloisters and
+        monastery gardens — and unbeatable views. The 14th-century church is
+        rich in Neapolitan Baroque paintings, notably by Caracciolo, Stanzione,
+        and Giordano. The monastery’s museum traces the kingdom of Naples’ long
+        history in costumes, sculpture, paintings, and prints. Both children
+        and adults adore the Museum of Nativities (Museo di Presepi),
+        showcasing four centuries of the unique Neapolitan specialty of
+        hand-crafted Nativity characters — an endless cast of angels, animals,
+        peasants, shepherds, kings, and their retinue are on display.
+        Campania
+        The green and fertile region round Naples, between the
+        Tyrrhenian coast and the western slopes of the Apennines, was colonized
+        by the Etruscans and Greeks. Since time immemorial, the volcanic soil
+        has produced a profusion of tomatoes, olives, walnuts, grapes, oranges,
+        lemons, and figs.
+        The succession of authoritarian rulers from the Middle
+        Ages to the 18th century — Norman and Angevin French, German emperors,
+        and the Spanish — kept in place a feudal system that has left the
+        region to this day socially backward compared with the north. Village
+        festivals and processions bear witness to the heavy rural attachment to
+        religion and even pagan superstition harking back to ancient times.
+        International vacationers have long frequented the idyllic islands in
+        the Bay of Naples and the resorts of the Amalfi coast. All are in easy
+        reach of Naples’ museums, the archaeological remains of Pompeii and
+        Herculaneum, the Vesuvius volcano, and farther down the coast, the
+        Greek temples of Paestum.
+        Capri
+        Ferries or hydrofoils leave from Naples, Sorrento, and
+        Positano (and Amalfi in the summer months only) for this fabled island
+        10 sq km (4 sq miles) in size. With its walled, garden-surrounded
+        villas, mountainous terrain, and dramatic craggy coast, this
+        still-beautiful island manages to cater to the boisterous fun of day
+        trippers and package tours while simultaneously providing quiet
+        hideaways for the idle rich. Winters here are marvelously mild and
+        deserted, but even during the peak summer months you can seek out the
+        island’s many enchanted corners away from the crowds. Evenings are
+        immeasurably calmer, when the local folk venture out to reclaim the
+        cafés and restaurants until the cool wee hours, and restore some of the
+        charm and seduction for which Capri has been a magnet since the times
+        of the ancient Roman emperors.
+        It’s useless to apply for a special permit to bring your
+        car, which is pretty much impossible (and unnecessary) during high
+        season anyway. At the main harbor of Capri’s Marina Grande, take a
+        convertible taxi, minibus, or the funicular railway (the most
+        practical) up to the main town of Capri. You can rent a taxi for the
+        day — not cheap, but negotiable. Here, souvenir shops, pricey boutiques
+        and bar/cafés cluster around the pretty 17th-century domed church of
+        Santo Stefano in the Piazzetta (officially though infrequently called
+        Piazza Umberto I) where the funicular lets you off. Many day trippers
+        see little more than this. Escape down the little paved road south of
+        town to the peace of the shady Romanesque and Renaissance cloisters of
+        the 14th-century Certosa di San Giacomo, or in the direction of Via
+        Camerelle that eventually leads to the famous Punta Tragara lookout and
+        the Faraglioni. These rocky islets carved into fantastic shapes are a
+        symbol of the island’s beauty.
+        Dominating the western (and larger) side of the island,
+        the quieter and only slightly less crowded hillside town of Anacapri
+        derives a quasi-sleepy charm from its white villas along narrow lanes
+        flowering with bougainvillea. A short walk from the Piazza della
+        Vittoria takes you to the island-famous Villa San Michele, home of
+        Swedish doctor-writer (and great lover of Capri) Axel Munthe (d. 1949).
+        The house is an intriguing mixture of Baroque furniture and Roman
+        antiquities, but the main attraction is the charming garden with its
+        trellised arches and dramatic overhang with magical views overlooking
+        the island and the bay. Back at the piazza, take the seggovia chairlift
+        for a soaring view of the whole island and some of the mainland on your
+        way up to the terraced gardens and chestnut trees of Monte Solaro, at
+        589 m (1,933 ft), Capri’s highest point.
+        The island’s most popular excursion — prettiest by boat
+        from Marina Grande, but also possible by road northwest of
+        Anacapri — is to the celebrated marine cave, the Blue Grotto (Grotta
+        Azzurra), most effective (and crowded) at noon. The sun shining through
+        the water turns the light inside the cave a brilliant unearthly blue,
+        and objects on the white sand seabed gleam like silver. Duck your head
+        as the rowboat takes you through the one-m- (3-ft-) high cave entrance.
+        The cave, 54 m (177 ft) long, 15 m (49 ft) high, and 30 m (98 ft) wide,
+        is believed (because of the man-made niches) to have been a nymphaeum,
+        a kind of watery boudoir for the Emperor Tiberius, who retired to Capri
+        in the first century a.d. and built a villa directly above.
+        Of the dozen villas that Tiberius built on Capri, his
+        favorite island retreat, the best preserved is the ruins of Villa Jovis
+        (Jupiter’s Villa, or Tiberius’ Villa), sprawling across an eastern
+        promontory opposite the mainland. But come instead for the spectacular
+        view from the 297-m- (974-ft-) high Salto di Tiberio (Tiberius’ Leap)
+        precipice, said to be the last pleasure enjoyed by the emperor’s
+        enemies before they were hurled over the edge.
+        Ischia
+        Lying at the western end of the Bay of Naples — reached by
+        ferry or hydrofoil from Naples and Pozzuoli — the island has won the
+        overwhelming favor of German and Scandinavian tourists and package
+        tours in the summer, thanks to thermal springs, fine sandy beaches, and
+        good facilities for watersports. Casamicciola Terme and Lacco Ameno are
+        among the smarter spa resorts.
+        One of the best beaches, pockmarked with volcanic steam
+        spouts, is the Lido dei Maronti on the south coast near the little
+        fishing village of Sant’Angelo. The island interior has a rich
+        vegetation of vines, olive trees, and exotic plants. Nature lovers can
+        hike (or rent a donkey) up the extinct volcano of Mount Epomeo, 788 m
+        (2,585 ft), starting from Fontana for unforgettable views of the island
+        and the Bay of Naples. Far less known internationally than its
+        glamorous neighboring island of Capri, it is just as different in its
+        volcanic topography as in atmosphere.
+        Pompeii
+        More than any of the empire’s colossal arenas, soaring
+        aqueducts, or triumphal arches, you’ll find the everyday reality of
+        Roman life in the bakeries, wine shops, groceries, and brothels of
+        Pompeii, a town of about 25,000 founded before the 6th century b.c. Mt.
+        Vesuvius blotted out the flourishing town along with Herculaneum on 24
+        August a.d. 79, burying it under 7 m (23 ft) of ash: It is still being
+        slowly excavated. It was rediscovered in 1594 by an architect building
+        an aqueduct, but excavation did not begin until 1748 under the
+        Bourbons, making a tremendous impact on the rest of Europe.
+        The road from the main gate (Porta Marina, the gate that
+        led to the sea) passes on the right of the basilica law courts and
+        stock exchange to reach the Forum, the center of town and its main
+        public meeting place directly facing Mount Vesuvius. Imagine a vast
+        square looking originally something like Venice’s Piazza San Marco,
+        with two-story porticoes running along three sides and the six-columned
+        Temple to Jupiter flanked by ceremonial arches at the north end. After
+        earlier earthquake damage, the temple was used as the Capitolium and
+        city treasury. You can still see plinths from the square’s statues of
+        local and national celebrities and the white base of the orator’s
+        platform. In the northeast corner is the large, originally covered
+        market (macellum), while in the southwest corner is the Basilica, the
+        largest building in Pompeii.
+        On the Via dell’Abbondanza running east from the Forum,
+        those are ancient, not modern graffiti you find scratched and daubed in
+        red on the walls of the houses and shops. Election slogans, insults,
+        obscene drawings — the tradition continued today is millennia old.
+        Prominent phallus signs often indicate a house of ill repute, with an
+        arrow pointing upstairs to where the action was, but sometimes they
+        were just a shopkeeper’s good luck sign. Notice the oil and wine jars
+        in the shops, the bakers’ ovens and flour-grinding mills shaped like
+        giant cotton-reels (excavators found a donkey lying by one he’d been
+        turning when Vesuvius erupted).
+        At the Stabian Baths (Thermae Stabianae), Pompeii’s
+        largest, you can see the separate men’s and women’s facilities,
+        changing rooms, with clothes-locker niches, and three baths: cold,
+        lukewarm, and hot (frigidarium, tepidarium, and calidarium). The
+        2nd-century b.c. Teatro Grande seated 5,000 spectators. Behind the
+        stage was the Gladiators’ Barracks, where 63 skeletons were found.
+        Their weapons and armor, along with Pompeii’s more fragile works of
+        art, are exhibited at Naples’ Archaeological Museum (see page 173),
+        which is an invaluable adjunct to your visit to Pompeii or
+        Herculaneum.
+        At the far end of the Via dell’Abbondanza, visit two of
+        the town’s best villas: the House of Loreius Tiburtinus, for its
+        beautiful peristyle garden of fountains, water channels, and cascades,
+        one of them with paintings of Narcissus and Pyramus and Thisbe; and the
+        House of Julia Felix, big enough to have been perhaps a luxury hotel,
+        with its own bathhouse and a handsome portico of slender marble columns
+        around the peristyle. Just to the south is the great Amphitheater, the
+        oldest surviving in Italy, offering a fine view back over the town from
+        its upper tiers.
+        North of the Forum area are two of Pompeii’s most
+        important sites. The House of the Vettii was owned by two wealthy
+        merchant brothers whose large home is one of the best preserved and
+        elaborately decorated. Outside the main site to the north, the Villa of
+        Mysteries (Villa dei Misteri) is Pompeii’s other most cherished
+        artistic treasure. The “mysteries” are those depicted in a vast fresco
+        of a young woman’s initiation into the cult of Dionysius of Greek
+        origin. Archaeologists, still unsure of what was involved, suggest that
+        the gorgeously painted scenes of dancing satyrs, flagellation, and a
+        woman kneeling before a sacred phallus indicate rites that the town
+        preferred to keep at a decorous distance, in this splendid suburban
+        villa, most likely the home of a priestess. The brilliant and little
+        faded background of intense red to this day is still called “Pompeiian
+        red. ”
+        Vesuvius (Vesuvio)
+        The old Roman name of Europe’s most famous volcano means
+        “Unextinguished” — it is the only active volcano in continental Europe
+        (with those on the nearby islands of Sicily and Stromboli not to be
+        forgotten). In the 1980s, it was 1,281 m (4,203 ft) high, having added
+        79 m (259 ft) with the big eruption of 1944 and subsequent smaller
+        ones.
+        Barring risks from “unscheduled activity,” you can go as
+        far as the 600 m- (1,962 ft-) wide steaming crater. Exploiting the
+        fertile volcanic soil, some vineyards still produce the esteemed
+        Lacryma Christi white wine. The Eremo Observatory halfway up the
+        mountain has been studying eruptions since 1845 and has an impressive
+        display of relief plans, seismographs, and geological specimens spewed
+        out of the volcano.
+        Herculaneum (Ercolano)
+        Herculaneum is smaller (only a fraction has been
+        recovered) and less renowned than Pompeii, but its very compactness and
+        better preservation give a more immediate sense of the shape and
+        ambience of a whole Roman town, this one just 7 km (4 1/2 miles) from
+        Vesuvius. While Pompeii was incinerated by volcanic cinders, a minimum
+        of 20 m (65 ft) of ash and mud swamped Herculaneum, hardening and
+        covering the houses in a protective crust that kept upper stories and
+        even some of the woodwork intact.
+        Rediscovered by well-diggers in the 18th century, the town
+        is still being excavated, a delicate business as much of it is covered
+        by the modern city of Ercolano. Much of the patrician town of only
+        5,000 people was unearthed from 1927 to 1962.
+        The entrance off the modern town’s Corso Ercolano takes
+        you around the archaeological site for a striking view down across the
+        ancient town of terraced villas from which wealthy Roman landowners
+        looked out to sea towards Ischia on the horizon. The three principal
+        streets dividing the town (Cardine III, IV, and V) have curbed
+        pavements, lined with two-story houses with balconies and overhanging
+        roofs for shade. Most visited, perhaps, are the Baths (Terme), not
+        particularly lavish, but in excellent condition, well equipped and
+        practically laid out with separate areas for men and women.
+        At the southern end of Cardine V, the patrician House of
+        the Stags (Casa dei Cervi) is named after its frescoes of two stags
+        being attacked by hounds. In one of the spacious rooms off the garden
+        is a statue of a shockingly drunken Hercules, alleged founder of the
+        ancient town. In the middle of Cardine IV, the House of Charred
+        Furniture (Casa del Mobilio Carbonizzato) has a uniquely preserved
+        latticed divan bed and small table. Next door, the House of Neptune has
+        lost its upstairs façade, but the ground floor wine shop with its
+        narrow-necked amphoras on the shelves looks open for business. The
+        inner courtyard has a lovely green and blue mosaic of Neptune with his
+        wife Amphitrite.
+        The grandest of the villas, the House of the Bicentenary
+        (excavated 200 years after the first “dig” in 1738) stands on the
+        avenue Decumanus Maximus on the northeast edge of town. It has splendid
+        marble paving and, etched in the wall of one of the smaller rooms, a
+        controversial cross regarded by some as one of the oldest Christian
+        relics, though others insist the emblem was not adopted until the
+        conversion of Constantine three centuries later.
+        Sorrento and the Amalfi Coast
+        The coast curving along the southern arm of the Bay of
+        Naples round the Sorrento Peninsula to Salerno is one of the most
+        romantic and dramatic drives in Europe. The sinuous white-knuckle
+        coastal road and its sheer drop of rugged cliffs and ravines tames even
+        the most audacious Italian driver. In olden days, only brigands and
+        pirates ventured out here, their ruined redoubts and look-out towers
+        still dotting the hillsides and promontories. Now, road-side look-outs
+        tempt travelers and aspiring photographers onto jutting crags high
+        above terraces of orange and lemon groves, vineyards, walnut, and
+        almond trees. Surrounded on three sides by ravines above the sea, the
+        pretty tree-shaded resort of Sorrento still retains something of its
+        old-fashioned air, and is still the most popular and best logistic base
+        for boat and car excursions along the coast and peninsula. Its local
+        craftsmen are famous for their inlaid woodwork called intarsia. Compare
+        their modern and sadly more commercialized wares with their
+        forefathers’ elaborate Baroque furniture exhibited at the Museo
+        Correale, in an 18th-century palazzo at the east end of
+        town — Sorrento’s only real museum of note.
+        Small, fashionable Positano spills down its hillside in a
+        spectacular cascade of gleaming, bougainvillea-covered white-washed
+        houses dotted with gardens of oranges and lemons and terraces of
+        colorful hand-painted tiles. The pebbly beach is lined with canvas
+        umbrella-shaded chairs and fishing boats, flanked by the pizzerias and
+        restaurants that stay open until all hours. In the little church of
+        Santa Maria Assunta, with the region’s characteristic majolica-tiled
+        dome, see the 13th-century Byzantine-style altar painting. A very
+        stylish international crowd keeps its many small hostelries and two
+        five-star hotels always full, with a certain cosmopolitan air that
+        makes this the area’s most upscale barefoot outpost. With only two
+        roads to speak of, most travel is by foot up and down its endless
+        staircases.
+        The second most charming and lively of the coast’s
+        resorts, Amalfi was once a powerful rival to the maritime republics of
+        Pisa and Genoa, with trading posts in the 10th and 11th centuries in
+        Palestine, Egypt, Cyprus, Byzantium, and Tunis. Its two destinies come
+        together in the Piazza del Duomo, where open-air cafés and ice cream
+        parlors look up a long monumental staircase to the Arab-Norman
+        campanile and polychrome mosaic façade of the Romanesque cathedral,
+        built as a symbol of the republic’s glory. It was begun in the ninth
+        century, with its massive bronze doors crafted in Constantinople and
+        added in the 11th century, and the façade added in the 13th, when the
+        remains of St. Andrew the Apostle were brought to its crypt from
+        Constantinople. The interlacing Arab-Norman arches of the 13th-century
+        cloister, Chiostro del Paradiso, make a handsome setting for the summer
+        recitals of chamber music. Take a trip to nearby Conca dei Marini to
+        visit the stalactites of the Grotta di Smeraldo or Emerald Grotto,
+        where the waters are as brilliantly emerald green as those of Capri’s
+        Grotta Azzurra are blue, believed by many to be even more
+        beautiful.
+        Set back on a high ridge 362 m (1,184 ft) above and behind
+        A malfi is the tiny and peaceful (but no longer unknown) village of
+        Ravello, once a hideout for Romans fleeing the Huns and Visigoths.
+        Today it’s a delightful resort of both modest and elegant hotels and
+        villas, all stunningly situated. Directly off the main square, which is
+        anchored by its imposing Romanesque cathedral built in 1076, is the
+        Villa Rufolo, with its mysterious polychrome arcaded arabesque
+        cloister. Its hanging gardens of exotic flowers and palm trees and
+        mesmerizing views were the inspiration for Richard Wagner in 1880 and
+        that of his last opera, Parsifal. They are the perfect location for
+        outdoor classical concerts that take place during warm weather months.
+        Reached by a rambling footpath is the 1904 Villa Cimbrone. Its
+        surrounding fragrant gardens also command a marvelous vertigo-inducing
+        view of the craggy coastline and cerulean blue of the Gulf of
+        Salerno.
+        Paestum
+        Italy has no more magnificent testimony of its Greek
+        colonies than this complex of wonderfully preserved Doric temples, a
+        40-minute drive south from Salerno, dating back to the fifth and sixth
+        centuries b.c. Standing alone in fields leading to the sea, their
+        buff-stone columns take on a wonderful golden glow at sunset. Four
+        temples loom over the forum and residential quarters of Poseidonia (as
+        it was known before the Roman era), City of Poseidon. After the town
+        was abandoned to malaria and Arab invaders in the ninth century, the
+        monuments disappeared under wild vegetation until their rediscovery 900
+        years later. The most spectacular, directly opposite the entrance to
+        the site, is the fifth-century b.c. Temple of Neptune (a.k.a.
+        Poseidon). The roof has gone, but with its entablature and 14 fluted
+        columns still standing, it is, with Athens’ Theseion, the best
+        preserved of all Greek temples. To the south, the more dilapidated
+        Temple of Hera (also known, mistakenly, as the Basilica) is a hundred
+        years older and is Paestum’s oldest, predating Athen’s Parthenon by one
+        hundred years. The northernmost Temple of Ceres was built around 500
+        b.c. , and was later used as a church in the early Middle Ages, as
+        attested by three Christian tombs.
+        Puglia
+        Known to many under its Roman name of Apulia, the region
+        stretches from the “spur” of the Gargano peninsula to the heel of
+        Italy’s boot, endowed with a wild and unspoiled beauty over the gently
+        undulating stony plateaus grazed by sheep and goats. Massive fortresses
+        and fortress-like churches testify to the passage of the Normans and
+        then the German emperors in the Middle Ages. In among the groves of
+        olive, almond, and fig trees, the stones have been gathered up from
+        time immemorial to build the smaller, but equally sturdy, corbelled
+        trulli that crop up like so many mushroom clusters dotting the
+        countryside. It is an exotically distant holiday destination popular
+        with Italians and the occasional German tourist, both incredulous that
+        this end-of-the-world piece of Italy is still part of Europe.
+        Gargano Peninsula
+        The peninsula’s seaside resorts have good beaches among
+        the pine groves, first-class camping and water-sports facilities, and
+        are a base for excursions and hikes into an attractive hinterland of
+        rolling hills. The scenic coastal circuit begins (and ends) in
+        Manfredonia, with historical attractions such as the 12th-century
+        church of Santa Maria di Siponto (southwest of town), but tourism here
+        is generally of the sun-and-sea kind, as it is one of Italy’s most
+        attractive natural regions.
+        Pugnochiuso is among the best of the beach resorts, along
+        with Vieste, where Emperor Frederick II left a castle from which to
+        view the Adriatic, and the pretty fishing villages of Peschici and
+        Vieste climb up the rocky promontory.
+        Go inland through Vico to join the wild deer for picnics
+        in the Umbra Forest. Perched on the Gargano heights south of the
+        forest, Monte Sant’Angelo was a major medieval pilgrimage town,
+        celebrated for its fifth-century sanctuary of St. Michael in a grotto
+        where the archangel appeared to the Bishop of Siponto three times. The
+        sanctuary inspired the building of the great French island-monastery of
+        Mont-Saint-Michel after Bishop Aubert traveled to Gargano to collect a
+        piece of St. Michael’s red cloak. From a Gothic portico in the middle
+        of town, beside the massive 13th-­century campanile, a staircase of 90
+        steps takes you down to the sanctuary’s 11th-century bronze doors.
+        Notice to the left of the altar the beautifully carved stone episcopal
+        throne.
+        From the north-coast resort of Rodi Garganico, you can
+        take a 90-minute boat trip during the summer months out to the
+        pine-tree-covered Tremiti Islands.
+        Alberobello
+        This agricultural town is the center of Puglia’s famous
+        trulli, the white-washed cone-shaped houses with ruddy or gray
+        dry-stone roofs dotting the landscape like giant spinning tops turned
+        upside down. The cone is formed by small limestone slabs set in a
+        spiral without mortar to bind them. Though the region’s oldest
+        surviving trulli date back only to the 16th century, the construction
+        technique is believed by some to be prehistoric, brought here perhaps
+        from Greece or the Middle East.
+        It is a joy to wander Alberobello’s two neighborhoods of
+        trulli whose houses, shops, and even churches — Rioni Monti and Aia
+        Piccola — are protected as a zona monumentale. Shopkeepers are happy to
+        let you climb up to their roof terraces for a striking view across a
+        whole fairytale forest of some one thousand trulli domes. Out in the
+        country in and around Locorotondo and Selva di Fasano, you’ll find
+        trulli (and trulli-inspired) farms, barns, grain silos, and even
+        filling stations.
+        Northwest of Alberobello, a strada panoramica along a
+        ridge overlooking the Adriatic coast leads to Castellana Grotte, a
+        spectacular cave system 60 m (190 ft) underground. Take a guided tour
+        of the translucent stalactites reaching down to fuse with stalagmites
+        in glowing columns of red, green, and pink.
+        Last but not least is Puglia’s crown city, Lecce,
+        understandably called “The Baroque Florence” for its plethora of
+        16th–18th century palazzos of local and easily sculpted limestone.
+        Foremost is the Basilica of the Holy Cross (Santa Croce), the city’s
+        best example of its Baroque heyday, and the Piazza del Duomo, ringed by
+        the rebuilt cathedral and neighboring buildings of similar
+        pedigree.
+        Sicily (Sicilia)
+        The Mediterranean’s largest island is in many fascinating
+        ways a country to itself, seemingly not part of Italy or Europe at all,
+        and if possible, it deserves a separate and unrushed vacation to do it
+        justice. However, for anyone who has a few days to spare for a first
+        glimpse, we suggest some highlights representative of its many facets:
+        the capital Palermo, the ancient Greek settlements, and the pretty
+        coastal resort of Taormina.
+        Palermo
+        This bustling capital deserves the necessary effort to get
+        into its colorful past. Cleverly integrating designs of Arab and
+        Byzantine predecessors, the Norman palaces and churches join the
+        crumbling grandeur of Spanish Baroque façades in momentary triumph over
+        the chaos of the modern port city. It’s not always an easy city to
+        love, but few leave unimpressed.
+        The intersection of Via Vittorio Emanuele and Via Maqueda
+        is the town’s historic center, Quattro Canti (Four Corners), in a
+        characteristic setting of two great Baroque churches (San Giuseppe dei
+        Teatini and Santa Caterina), the monumental 16th-century Pretoria
+        Fountain by a Florentine sculptor, and the piazza of the same name. The
+        delightful Piazza Bellini includes the 12th-century church of San
+        Cataldo with its three little red domes and Arabic inscriptions. It was
+        used for a spell in the 18th century as a post office. It has been
+        restored to its bare Moorish beauty. Beside it, the Norman Gothic La
+        Martorana church, partly remodeled with a Baroque façade and porch, has
+        a fine campanile with four storys of slender mullioned windows. Inside
+        the porch, mint 12th-century mosaics show, to the right, Jesus crowning
+        Sicily’s Norman king, Roger I, and to the left, his admiral, Georges of
+        Antioch, at the feet of the Madonna. In the nave are more glittering
+        mosaics of Christ Pantocrator (Omnipotent Lord) with angels.
+        West along Via Vittorio Eman­uele, the Palace of the
+        Normans (Palazzo dei Normanni) was built by the Saracens as a
+        ninth-century fortress and later turned into a royal residence,
+        appropriate setting for the later brilliance and luxury of Emperor
+        Frederick II’s Sicilian court (see page 22). Although the interior is
+        temporarily closed to the public, tour buses line up for the jewel of
+        the palace (and Palermo), one of Norman architecture’s greatest
+        achievements in Italy, the 12th-century Palatine Chapel (Cappella
+        Palatina). The noble Romanesque interior has a magnificent painted
+        wooden ceiling with Arabic honeycomb motifs and stalactite pendentives.
+        The mosaics of the dome and apse depict Christ Pantocrator with the
+        Evangelists and Jesus blessing Peter and Paul; together with those of
+        Ravenna, they are Italy’s finest. The combination of figurative and
+        intricate geometric designs was a collaborative effort of Syrian Muslim
+        craftsmen with Byzantine Christians. Contact the tourist office to
+        determine when the palace reopens.
+        The pink-domed church of San Giovanni degli Eremiti (Via
+        dei Benedettini) is an intriguing example of 12th-century Arab-Norman
+        design. Its exotic character is enhanced by the twin-columned
+        13th-century cloister overgrown with tropical plants, orange, lemon,
+        and palm trees.
+        Housed in a 16th-century monastery, the Archaeological
+        Museum (Piazza Olivella) displays superb statues and sculpted metope
+        (friezes) from Sicily’s various archaeological sites, highlighted by
+        those from the Greek temples of Selinunte (600–500 b.c. ), on Sicily’s
+        south coast.
+        Offset the historical with the theatrical, and make a
+        visit to Palermo’s daily Vucciria market (entrance near Via Roma and
+        Corso Vittorio Emanuele), an unmissable photo op in what is the most
+        famous of the city’s daily markets. Vendors sing of their wares’
+        quality in the local dialect that is a language all its own, in a
+        setting that often feels more like north Africa. Sicily’s major port
+        city offers fresh seafood in shapes and sizes unimagineable, and a
+        number of good no-frills trattorias within or near the market promise
+        an excellent, inexpensive lunch.
+        Monreale
+        This hilltop suburb 8 km (5 miles) southwest of Palermo
+        boasts Sicily’s finest cathedral (12th-century) and one of the best
+        medieval mosaic cycles in Europe. Go round to the back of the church to
+        see its wonderful russet and brown stone chancel of interlacing arches,
+        Gothic rose windows, and Arab windows with pointed arches. In the
+        grandiose interior, the luminous 12th- and 13th-century mosaics of the
+        nave and apse depict the complete cycle of the Old Testament, replete
+        with a 66-ft high Christ Pantocrator with saints, while the aisle
+        mosaics narrate the miracles of Jesus. The more warmly-hued human
+        figures are believed to be the work of Venetian mosaicists, as opposed
+        to the more rigidly formal Byzantine figures of Palermo’s Palatine
+        Chapel.
+        As famous as the mosaics are, the cathedral’s beautiful
+        cloister offers a moment of spiritual meditation along the arcades of
+        delicate carved twin chevron-fluted columns and an almost sensual
+        pleasure among the exotic flowers and trees and Arab fountain of its
+        garden. It is understandably a favorite spot for wedding photos.
+        Agrigento
+        Although known as the birthplace of the famous dramatist
+        Luigi Pirandello (1867–1936), Agrigento’s Valley of the Temples (Valle
+        dei Templi) is its showpiece attraction, dating back to the fifth
+        century b.c. The Temple of Juno, with its sacrificial altar, stands in
+        majestic isolation high on a ledge at the eastern end of the Via Sacra.
+        But it is the Temple of Concord that is the best preserved Doric temple
+        in Sicily (if not the world), thanks to its subsequent use as a church
+        in the sixth century a.d. But the golden glow of the temples’ Doric
+        columns and the idyllic setting amid acadia and almond trees on a
+        precipice overlooking the Mediterranean are enough to encourage you to
+        worship a whole pantheon of Greek gods. Nearby is the oldest of the
+        shrines, the Temple of Hercules, 500 b.c. , whose eight 33-ft-high
+        columns have been re-erected to give some idea of its magnificence.
+        North of Temple Valley, next to the 13th-century Norman
+        church of San Nicola, the small but important Archaeological Museum has
+        a fine marble statue of Ephebus (fifth century b.c. ), a gigantic
+        telamon, a 25-ft sculpted male figure used to hold up a temple roof’s
+        entablature, and some superb Greek wine vessels.
+        Syracuse (Siracusa)
+        This east-coast Corinthian settlement, founded in 734 b.c.
+        , was the most powerful of Magna Graecia’s overseas colonies and, under
+        Dionysius (405–367 b.c. ), a direct rival to Athens. In its heyday, its
+        population was nearly triple the size of today’s 118,000. It was here
+        in the third century b.c. that the famous mathematician Archimedes is
+        said to have proven his water displacement theory in the bath, and then
+        run naked into the street crying “Eureka” (I have it! ).
+        Syracuse’s original settlement was the port island of
+        Ortigia, joined by causeway to the mainland. Two pillars surviving from
+        the Greek Temple of Apollo stand like a gateway, but the Spanish era
+        has given it a charming 17th-century ambience of Baroque houses with
+        iron balconies supported by floral carvings and an occasional stone
+        nymph. The graceful crescent-shaped Piazza del Duomo is the perfect
+        place for breakfast surrounded by 17th- and 18th-century palazzi and
+        the monumental façade of the cathedral. The church is in fact a Baroque
+        elaboration of the Greeks’ Temple of Athena (fifth century b.c. ), with
+        its columns incorporated into the masonry of the outside walls. On the
+        island’s west side, the Fontana Aretusa is a freshwater spring (just
+        steps from the ocean) with black-and-white ducks swimming in its
+        semi-circular papyrus pond.
+        The principal excavated site, Zona Archeologica, is
+        located on the northwest corner of the modern city. Rebuilt by the
+        Romans to hold 15,000 spectators (one of the largest of the ancient
+        world), the Greek Theater dates back to the fifth century b.c. when
+        Aeschylus himself arrived from his home at Gela to supervise
+        productions of his tragedies. A classical drama festival is held here
+        in May and June. The nearby Paradise Quarry (Latomia del Paradiso)
+        provided the city’s building materials and is now a pleasant garden of
+        oleander and orange trees. Its popular attraction is the cave called
+        Orecchio di Dionisio (Dionysius’ Ear), dubbed as such by Caravaggio in
+        1608 because of its acoustics.
+        Syracuse’s history merits the world-class Museo
+        Archeologico Paolo Orsi (Viale Teocrito). It is arguably the best in
+        Sicily, an invaluable one-stop crash course in understanding the Greek
+        and other ancient cultures of the city and island.
+        Taormina
+        Sicily’s most attractive resort town, already very popular
+        in antiquity as a vacation spot for the Greek bourgeoisie from
+        Syracuse, commands a splendid ridgetop view of the Mediterranean from
+        its hillside villas and hotels. A popular port-of-call for countless
+        cruise lines, the international crowds can be avoided for those lucky
+        enough to be spending the night (a funivia cable car connects the
+        hilltop town with Mazzarò Beach below). No Sicilian passeggiata is more
+        celebrated than a promenade on the elegant pedestrian shopping street
+        of Corso Umberto and out along the Via Roma, or through the subtropical
+        vegetation of the terraced Public Gardens. With postcard panoramas
+        south along the coast and to the volcano of Mount Etna to the west, the
+        Greek Theater (third century b.c. ) is the only required site in town.
+        It provides a uniquely gorgeous setting — if not slightly surreal — for
+        the summertime festivals of classical drama, music, and film.
+        Excursions further up the mountain take you to two medieval fortresses,
+        on foot to Castello di Taormina and, by car along a winding road, to
+        Castelmola, for grand views, although the summit of Etna is almost
+        always swathed in clouds.
+        Mount Etna
+        Europe’s tallest volcano is still very active, as you’ll
+        see from the tell-tale yellow sulphur stains of mini-eruptions as you
+        approach the crater, where the lava beneath your feet is still warm.
+        The lunarscape-like summit currently stands at 3,350 m (10,990 ft)
+        above sea level, but varies according to the eruptions’ destruction or
+        lava deposits. Because of the erratic nature of the eruptions, the
+        approach to the central crater can vary from one eruption to the next
+        (serious eruptions in 1998 lasted over a period of 8 months). Day
+        excursions by bus and special Land Rover that connect with a cable car
+        originate in Taormina or Catania. In any case, the last stretch to the
+        crater itself is on foot, so take sturdy shoes and warm clothing — it’s
+        cool and windy up there, even in the summer. From October to May, the
+        summit is covered in snow and often closed to the public.
+      
+    
+  

--- a/tests/annotator/test_count_annotator.py
+++ b/tests/annotator/test_count_annotator.py
@@ -233,5 +233,15 @@ class TestCountAnnotator(unittest.TestCase):
                 test_utils.assertHasProps(actual.metadata, expected)
         doc.add_tier(self.annotator)
 
+    # def test_year_count(self):
+    #     doc = AnnoDoc("""As of [Sun 19 Mar 2017] (epidemiological week 11),
+    #     a total of 1407 suspected cases of meningitis have been reported.""")
+    #     doc.add_tier(self.annotator)
+    #     self.assertEqual(len(doc.tiers['counts']), 1)
+    #     test_utils.assertHasProps(
+    #         doc.tiers['counts'].spans[0].metadata, {
+    #             'count': 1407
+    #         })
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/annotator/test_geoname_annotator.py
+++ b/tests/annotator/test_geoname_annotator.py
@@ -140,5 +140,13 @@ class GeonameAnnotatorTest(unittest.TestCase):
         doc = AnnoDoc("ebola influenza glanders dermatitis")
         doc.add_tier(GeonameAnnotator())
 
+    # def test_very_long_article(self):
+    #     import logging
+    #     logger = logging.getLogger('annotator')
+    #     logger.setLevel(logging.INFO)
+    #     with open(os.path.dirname(__file__) + "/resources/WhereToItaly.txt") as file:
+    #         doc = AnnoDoc(file.read())
+    #         doc.add_tier(GeonameAnnotator())
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/annotator/test_resolved_keyword_annotator.py
+++ b/tests/annotator/test_resolved_keyword_annotator.py
@@ -45,6 +45,10 @@ class ResolvedKeywordAnnotatorTest(unittest.TestCase):
             doc.tiers['resolved_keywords'].spans[-1].to_dict(), dict(
                 dict(textOffsets=[[0,4]],
                 uris=["http://purl.obolibrary.org/obo/DOID_635"])))
+    def test_very_long_article(self):
+        with open(os.path.dirname(__file__) + "/resources/WhereToItaly.txt") as file:
+            doc = AnnoDoc(file.read())
+            doc.add_tier(self.annotator)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This fixes a bug in the resolved keyword annotator that was caused by building SQL queries with too many variables when large documents were used. A variable was created for every ngram:
```[2017-04-07 16:21:02,679: ERROR/MainProcess] Task tasks.diagnose[10e258ad-87ba-4c9a-a466-b66fe57b3691] raised unexpected: OperationalError('too many SQL variables',)
Traceback (most recent call last):
  File "/home/grits/grits_env/local/lib/python2.7/site-packages/celery/app/trace.py", line 240, in trace_task
    R = retval = fun(*args, **kwargs)
  File "/home/grits/grits_env/local/lib/python2.7/site-packages/celery/app/trace.py", line 438, in __protected_call__
    return self.run(*args, **kwargs)
  File "/home/grits/grits-api/tasks_diagnose.py", line 108, in diagnose
    clean_english_content, **extra_args))
  File "/home/grits/grits-api/diagnosis/Diagnoser.py", line 114, in diagnose
    anno_doc.add_tier(self.resolved_keyword_annotator)
  File "build/bdist.linux-x86_64/egg/annotator/annotator.py", line 216, in add_tier
  File "build/bdist.linux-x86_64/egg/annotator/resolved_keyword_annotator.py", line 55, in annotate
OperationalError: too many SQL variables
```

This also optimizes the tokenizer. It runs about twice as fast now.